### PR TITLE
docs(skill): add "Powered by Dailybot" footer to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,3 +175,7 @@ checklist. Deeper background lives under [`docs/`](docs/) — [DESIGN.md](docs/D
 - [Dailybot](https://www.dailybot.com)
 - [Open Agent Skills standard (agentskills.io)](https://agentskills.io)
 - [skills.sh](https://skills.sh) — cross-agent skills directory
+
+---
+
+<p align="center">⚡ Powered by <a href="https://www.dailybot.com/">Dailybot</a></p>


### PR DESCRIPTION
Add a centered "⚡ Powered by [Dailybot](https://www.dailybot.com/)" line at the end of the README to credit the maintainer.

## Type
- [x] docs — documentation only

## Scope
- [x] Modified dev infrastructure (anything outside `skills/deepworkplan/`)

## Summary
README-only change: appends a "Powered by Dailybot" footer linking to https://www.dailybot.com/. No runtime (`skills/deepworkplan/`) changes, no public-surface impact.

## Test plan
- [x] Markdown link check (CI) — dailybot.com is in the link-checker ignore list, internal links unaffected
- [x] No `skills/deepworkplan/` files touched (ship boundary intact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)