### PR TITLE
docs(skill): official Dailybot "Powered by" section in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,6 @@ checklist. Deeper background lives under [`docs/`](docs/) — [DESIGN.md](docs/D
 - [Open Agent Skills standard (agentskills.io)](https://agentskills.io)
 - [skills.sh](https://skills.sh) — cross-agent skills directory
 
----
+## :electric_plug: Powered by [Dailybot](https://www.dailybot.com?utm_source=dailybotopensource&utm_medium=deepworkplan-skill)
 
-<p align="center">⚡ Powered by <a href="https://www.dailybot.com/">Dailybot</a></p>
+Dailybot is an [AI Assistant](https://www.dailybot.com/product/ai) powered by ChatGPT that takes chat and collaboration to the next level helping to automate: daily standups, team check-ins, surveys, kudos, virtual watercooler, 1:1 intros, motivation tracking, chatops and more. [Learn more](https://www.dailybot.com?utm_source=dailybotopensource&utm_medium=deepworkplan-skill).


### PR DESCRIPTION
Replace the simple centered footer (currently on `main`) with the standard **Dailybot** open-source "Powered by" section — the same format used in [DailybotHQ/universal-emoji-parser](https://github.com/DailybotHQ/universal-emoji-parser): an electric-plug heading linking to dailybot.com plus the product blurb, with utm tags set to `deepworkplan-skill`. Brand spelled "Dailybot".

## Type
- [x] docs — documentation only

## Scope
- [x] Modified dev infrastructure (anything outside `skills/deepworkplan/`)

## Preview
```
## ⚡ Powered by Dailybot

Dailybot is an AI Assistant powered by ChatGPT … daily standups, team check-ins,
surveys, kudos, virtual watercooler, 1:1 intros, motivation tracking, chatops and
more. Learn more.
```

## Test plan
- [x] README-only change; no `skills/deepworkplan/` files touched (ship boundary intact)
- [x] dailybot.com links are in the markdown-link-check ignore list

🤖 Generated with [Claude Code](https://claude.com/claude-code)