### PR TITLE
ci(release): harden auto-release against quotes in commit messages

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -112,8 +112,9 @@ jobs:
 
       - name: Bump version in ALL SKILL.md files
         if: steps.version.outputs.skip != 'true'
+        env:
+          NEW_VERSION: ${{ steps.version.outputs.new_version }}
         run: |
-          NEW_VERSION="${{ steps.version.outputs.new_version }}"
           # Sync the new version across every SKILL.md under skills/deepworkplan
           # (router + create/execute/refine/resume/status/onboard + addons).
           while IFS= read -r f; do
@@ -122,10 +123,14 @@ jobs:
 
       - name: Update CHANGELOG.md
         if: steps.version.outputs.skip != 'true'
+        env:
+          NEW_VERSION: ${{ steps.version.outputs.new_version }}
+          # Passed via env (NOT inlined with ${{ }}) so commit messages
+          # containing quotes, backticks, or $() can't break or inject into
+          # this shell script.
+          COMMITS: ${{ steps.version.outputs.commits }}
         run: |
-          NEW_VERSION="${{ steps.version.outputs.new_version }}"
           DATE=$(date -u +%Y-%m-%d)
-          COMMITS="${{ steps.version.outputs.commits }}"
 
           # Build the new section.
           {
@@ -157,9 +162,10 @@ jobs:
 
       - name: Commit, tag, push
         if: steps.version.outputs.skip != 'true'
+        env:
+          NEW_VERSION: ${{ steps.version.outputs.new_version }}
+          NEW_TAG: ${{ steps.version.outputs.new_tag }}
         run: |
-          NEW_VERSION="${{ steps.version.outputs.new_version }}"
-          NEW_TAG="${{ steps.version.outputs.new_tag }}"
           git add -A
           git commit -m "chore(release): ${NEW_VERSION} [skip ci]"
           git tag -a "$NEW_TAG" -m "Release ${NEW_VERSION}"


### PR DESCRIPTION
## Summary

The auto-release job [failed](https://github.com/DailybotHQ/deepworkplan-skill/actions/runs/26731715588/job/78776896421) on the last merge to `main` (exit code 127).

**Root cause:** the *Update CHANGELOG.md* step built the commit list with
`COMMITS="${{ steps.version.outputs.commits }}"`. GitHub Actions expands
`${{ }}` into the script **source** before bash runs it, so a commit
message containing a literal double quote —

> `docs(skill): use the official Dailybot "Powered by" section in the README`

— terminated the bash string early, and the leftover text `by section in
the README` was executed as a command (`No such file or directory`,
exit 127). It's also a textbook GitHub Actions script-injection vector.

## Fix

Pass `NEW_VERSION`, `NEW_TAG`, and `COMMITS` through `env:` instead of
inlining them with `${{ }}`. Bash now receives them as real environment
variables that are never re-parsed as script source, so quotes,
backticks, and `$()` in any commit message are inert. Applied the same
hardening to the *Bump version* and *Commit, tag, push* steps for
consistency.

## Validation

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/auto-release.yml'))"` → OK
- No behavior change to the version-bump logic; once merged, auto-release re-runs over the same backlog and should cut the pending release cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)