### PR TITLE
ci(release): harden release push order + bump checkout to v5

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -38,7 +38,7 @@ jobs:
     # Skip our own release commits to prevent an infinite loop.
     if: ${{ !startsWith(github.event.head_commit.message, 'chore(release):') }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           # Uses `AUTOMATION_GITHUB_TOKEN` (the org convention) so the bot
@@ -168,8 +168,16 @@ jobs:
         run: |
           git add -A
           git commit -m "chore(release): ${NEW_VERSION} [skip ci]"
+          # Push the branch FIRST. If main is rejected (e.g. branch
+          # protection), we bail out here BEFORE creating/pushing the tag, so
+          # a failed run can never leave a dangling tag pointing at a commit
+          # that isn't reachable from main (which would block every future
+          # release with an "already exists" tag push).
+          git push origin HEAD:main
+          # main accepted the release commit — now tag that exact commit and
+          # push the tag on its own.
           git tag -a "$NEW_TAG" -m "Release ${NEW_VERSION}"
-          git push origin main --follow-tags
+          git push origin "refs/tags/${NEW_TAG}"
 
       - name: Create GitHub Release
         if: steps.version.outputs.skip != 'true'


### PR DESCRIPTION
## Summary

Follow-up hardening to the auto-release job, on top of the quoting fix in #4. Triggers a clean `2.1.0` release once merged (now that `AUTOMATION_GITHUB_TOKEN` is configured).

### 1. Push `main` before tagging
The previous step ran `git push origin main --follow-tags`, which pushes the branch and the tag as **independent refs**. When the protected `main` push was rejected, the tag had *already* been pushed — leaving a dangling `vX.Y.Z` tag pointing at a commit not reachable from `main`. That tag then blocks every future release (`tag already exists`). This is exactly what happened with `v2.1.0` (since cleaned up).

Now the job pushes `HEAD:main` first and only creates + pushes the tag **after** main accepts the release commit. A rejection now leaves no tag behind.

### 2. `actions/checkout@v4 → @v5`
Runs on Node 24 and clears the `Node.js 20 actions are deprecated` runner warning (Node 20 is force-removed from runners after June 16, 2026).

## Validation
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/auto-release.yml'))"` → OK
- Version-bump/changelog logic unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)