### PR TITLE
Feat/router start here

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,7 @@ the same instructions other agents do.
 | `refine` sub-skill | [skills/deepworkplan/refine/SKILL.md](skills/deepworkplan/refine/SKILL.md) |
 | `resume` sub-skill | [skills/deepworkplan/resume/SKILL.md](skills/deepworkplan/resume/SKILL.md) |
 | `status` sub-skill | [skills/deepworkplan/status/SKILL.md](skills/deepworkplan/status/SKILL.md) |
+| `verify` sub-skill (conformance check) | [skills/deepworkplan/verify/SKILL.md](skills/deepworkplan/verify/SKILL.md) |
 | `onboard` sub-skill (make any repo AI-first) | [skills/deepworkplan/onboard/SKILL.md](skills/deepworkplan/onboard/SKILL.md) |
 | `author` sub-skill (author/update skills, agents, commands) | [skills/deepworkplan/author/SKILL.md](skills/deepworkplan/author/SKILL.md) |
 | Methodology guide | [skills/deepworkplan/guide/GUIDE.md](skills/deepworkplan/guide/GUIDE.md) |
@@ -98,6 +99,7 @@ deepworkplan-skill/
     ├── refine/SKILL.md                         ← refine a draft / modify a final plan
     ├── resume/SKILL.md                         ← resume an interrupted plan
     ├── status/SKILL.md                         ← report plan status
+    ├── verify/SKILL.md                         ← verify repo/plan conformance (read-only)
     ├── onboard/SKILL.md                        ← make any repo AI-first (+ presets/)
     ├── author/SKILL.md                         ← author/update skills, agents, commands (+ templates/)
     ├── guide/GUIDE.md                          ← methodology guide

--- a/skills/deepworkplan/SKILL.md
+++ b/skills/deepworkplan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: deepworkplan
-description: DeepWorkPlan — turn any repo AI-first and run Deep Work Plans. Routes to create, execute, refine, resume, status, and repo-onboarding sub-skills based on intent. Use when the developer wants to plan, execute, or manage structured multi-task work, or make a repository AI-agent-ready.
+description: DeepWorkPlan — turn any repo AI-first and run Deep Work Plans. Routes to create, execute, refine, resume, status, verify, and repo-onboarding sub-skills based on intent. Use when the developer wants to plan, execute, manage, or verify structured multi-task work, or make a repository AI-agent-ready.
 version: "2.1.0"
 documentation_url: https://deepworkplan.com
 user-invocable: true
@@ -39,7 +39,10 @@ plain install). Before routing anywhere else:
    replacing anything. The result: `AGENTS.md` + `CLAUDE.md` symlink, a reasoned
    `docs/` tree, per-module docs, a `.agents/` kit, and a gitignored `.dwp/` — the
    repository becomes the agent harness.
-3. **Then plan and execute.** With the harness in place, create and execute Deep
+3. **Verify conformance.** Read [`verify/SKILL.md`](verify/SKILL.md) and run it to
+   confirm, objectively, that the repository now meets the standard (AGENTS.md with
+   real commands, the `.agents/` catalog, the gitignored `.dwp/`, and so on).
+4. **Then plan and execute.** With the harness in place, create and execute Deep
    Work Plans (below) — long-horizon, gated, resumable work an agent can run
    autonomously for hours.
 
@@ -67,6 +70,7 @@ full step-by-step flow.
 | "refine the draft", "modify the plan", "/dwp-refine" | **Refine** → read [`refine/SKILL.md`](refine/SKILL.md) |
 | "resume", "continue the interrupted plan", "/dwp-resume" | **Resume** → read [`resume/SKILL.md`](resume/SKILL.md) |
 | "plan status", "what's left", "/dwp-status" | **Status** → read [`status/SKILL.md`](status/SKILL.md) |
+| "verify", "is this repo AI-first?", "check conformance", "/dwp-verify" | **Verify** → read [`verify/SKILL.md`](verify/SKILL.md) |
 | "make this repo AI-first", "onboard this repo", "set up AGENTS.md + docs + .agents" | **Onboard** → read [`onboard/SKILL.md`](onboard/SKILL.md) |
 | "create/update a skill or agent", "evolve the kit", "/skill-create", "/agent-create" | **Author** → read [`author/SKILL.md`](author/SKILL.md) |
 

--- a/skills/deepworkplan/SKILL.md
+++ b/skills/deepworkplan/SKILL.md
@@ -18,6 +18,33 @@ a gitignored `.dwp/` directory at the repo root (`.dwp/plans/`, `.dwp/drafts/`).
 
 Source of truth: <https://deepworkplan.com>. License: MIT.
 
+## Start here (first run)
+
+This skill is a self-sufficient entry point: whether a developer arrives from
+<https://deepworkplan.com/init.md> or simply installs this skill, the setup plan
+is the same — and it lives here, so no network is required.
+
+**If the repository is not yet AI-first** — there is no root `AGENTS.md` and no
+`.agents/` directory — the recommended first action is to **onboard it**, even if
+the developer's request was vague ("set this up", "make this repo AI-first", or a
+plain install). Before routing anywhere else:
+
+1. **Read the standard locally.** Read [`spec/`](spec/README.md) (five RFC-2119
+   documents) and [`shared/adaptation.md`](shared/adaptation.md). The overriding
+   rule is **REASON, do not copy-paste**: this skill is the reusable engine; what
+   you produce must be adapted to *this* repository, never templated.
+2. **Run onboarding.** Read [`onboard/SKILL.md`](onboard/SKILL.md) and execute it.
+   It is **non-destructive**: detect existing `AGENTS.md`, `docs/`, `.agents/`, or
+   `CLAUDE.md`, reconcile rather than overwrite, and ask the developer before
+   replacing anything. The result: `AGENTS.md` + `CLAUDE.md` symlink, a reasoned
+   `docs/` tree, per-module docs, a `.agents/` kit, and a gitignored `.dwp/` — the
+   repository becomes the agent harness.
+3. **Then plan and execute.** With the harness in place, create and execute Deep
+   Work Plans (below) — long-horizon, gated, resumable work an agent can run
+   autonomously for hours.
+
+**If the repository is already AI-first**, skip onboarding and route by intent.
+
 ## What it does
 
 This is the **router**. It does not run any flow itself — it maps the

--- a/skills/deepworkplan/execute/SKILL.md
+++ b/skills/deepworkplan/execute/SKILL.md
@@ -98,6 +98,29 @@ Rules (strict):
 **Stop conditions:** all tasks `[x]`; a validation fails; the user requests a
 pause; a blocking issue.
 
+#### Autonomous mode (long-horizon, hours-long runs)
+
+A Deep Work Plan is designed to be executed **autonomously for hours**, across
+many tasks and even across a context-window reset. When the developer asks to run
+unattended (or passes `trust` / `auto`):
+
+- **Continue without per-task confirmation.** Run task → validate → commit →
+  update `PROGRESS.md` → next task, in a loop. Do not stop to ask "shall I
+  continue?" between tasks.
+- **Stop only on a real boundary:** a failed validation gate, genuine ambiguity,
+  a blocking dependency, an unsafe/destructive action outside the plan's scope, or
+  plan completion. On a stop, log the reason in the task's Completion & Log and
+  report.
+- **Checkpoint every task.** Progress lives on disk — the README checkboxes, each
+  task's Completion & Log, and `PROGRESS.md` (summaries, key decisions, important
+  values/paths). After each task this state MUST be current, because it is the
+  only thing that survives a context-window reset.
+- **Resume from disk, not memory.** If context is exhausted or a fresh agent takes
+  over, do not rely on conversation history: re-read the plan README, `PROGRESS.md`,
+  and the Completion & Logs, then continue at the first `[ ]` task (this is exactly
+  what the `resume` sub-skill does). Re-anchor to the plan goal before each task to
+  prevent drift over the long horizon.
+
 #### Step 5.0.1 — Team-Agents Parallel Groups
 
 > **CRITICAL: use REAL team agents, NOT subagents.** When the plan has a "Team

--- a/skills/deepworkplan/onboard/SKILL.md
+++ b/skills/deepworkplan/onboard/SKILL.md
@@ -290,8 +290,8 @@ and **stack-appropriate**, not generic boilerplate.
   `security-auditor`, plus any **stack-specific** role the preset suggests
   (e.g. a Django `migration-author`, a Vue `component-author`). Each persona
   must be described well enough that a non-Claude agent can read it.
-- **`.agents/commands/`** — the five short DWP commands (`dwp-create`,
-  `dwp-execute`, `dwp-refine`, `dwp-resume`, `dwp-status`) plus stack-relevant
+- **`.agents/commands/`** — the six short DWP commands (`dwp-create`,
+  `dwp-execute`, `dwp-refine`, `dwp-resume`, `dwp-status`, `dwp-verify`) plus stack-relevant
   ones (`code-review`, `pr`, `commit`, `branch`). **The `dwp-*` commands MUST be
   thin delegators, NOT copies of the flow.** Each is a short file (frontmatter
   `description:` + a body) that routes the invocation to the matching sub-skill
@@ -439,10 +439,10 @@ After generating, run this checklist in the target repo. On any failure,
 5. **`.agents/`** has `agents/`, `commands/`, `skills/`, `docs/`, `settings.json`
    and a `.claude → .agents` symlink (or documented fallback);
    `skills_agents_catalog.md` and `COMMANDS_REFERENCE.md` **match** what was
-   actually created (no phantom entries). **The five `dwp-*` commands exist** in
+   actually created (no phantom entries). **The six `dwp-*` commands exist** in
    `.agents/commands/` (`dwp-create`, `dwp-execute`, `dwp-refine`, `dwp-resume`,
-   `dwp-status`) and are thin delegators (no leftover `<skill-path>` placeholder,
-   no copied flow body).
+   `dwp-status`, `dwp-verify`) and are thin delegators (no leftover `<skill-path>`
+   placeholder, no copied flow body).
 6. **DeepWorkPlan skill is discoverable** and `.dwp/` exists, is gitignored
    (`git check-ignore .dwp` confirms), and has `plans/` + `drafts/`. **`tmp/`
    exists and is gitignored** (`git check-ignore tmp` confirms).

--- a/skills/deepworkplan/verify/SKILL.md
+++ b/skills/deepworkplan/verify/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: deepworkplan-verify
+description: Verify that a repository is DeepWorkPlan-conformant (AI-first) and that its plans are well-formed, producing an objective pass/fail report. Use when the developer asks to verify, audit, or check conformance of a repo or a plan.
+version: "2.1.0"
+documentation_url: https://deepworkplan.com
+user-invocable: true
+allowed-tools: Bash, Read, Grep, Glob
+---
+
+# DeepWorkPlan — Verify (conformance check)
+
+Check, objectively, whether a repository is **DeepWorkPlan-conformant** (AI-first
+and agent-pilotable) and whether its Deep Work Plans are well-formed. This
+sub-skill is **read-only**: it reports pass/fail, it does not change files. The
+normative criteria are defined in the specification's Conformance document
+(<https://deepworkplan.com/spec>).
+
+## Shared resources (read these)
+
+- [`../shared/context.sh`](../shared/context.sh) — resolve the repo root and `.dwp/`.
+- [`../shared/dwp-paths.md`](../shared/dwp-paths.md) — plans live at `.dwp/plans/PLAN_{name}/`.
+
+## Parameter support
+
+- `/dwp-verify` — verify the repository (the default).
+- `/dwp-verify plan {name}` — also verify a specific plan's well-formedness.
+- `/dwp-verify all` — verify the repository and every plan under `.dwp/plans/`.
+
+## The overriding rule
+
+Report what is **true on disk**, not what should be true. A criterion passes only
+if the artifact exists *and* carries real, repository-specific content. A generic
+stub, a placeholder, or a command that cannot run in this repository **fails** the
+criterion — say so explicitly. Never mark a check passed without evidence.
+
+## Repository checks
+
+Run these from the repo root and record each result. Prefer the mechanical check;
+fall back to reading the file when judgment is required (for example, deciding
+whether `AGENTS.md` commands are real).
+
+```bash
+# 1. AGENTS.md at the root, with a Quick Commands block
+test -f AGENTS.md && grep -qiE 'quick commands|## commands' AGENTS.md && echo "AGENTS.md: ok" || echo "AGENTS.md: FAIL"
+
+# 2. CLAUDE.md resolves to AGENTS.md (symlink or equivalent single source)
+[ -L CLAUDE.md ] && [ "$(readlink CLAUDE.md)" = "AGENTS.md" ] && echo "CLAUDE.md symlink: ok" || echo "CLAUDE.md symlink: CHECK"
+
+# 3. docs/ with the standard categories
+test -d docs && echo "docs/: present" || echo "docs/: FAIL"
+for d in ARCHITECTURE STANDARDS TESTING_GUIDE DEVELOPMENT_COMMANDS SECURITY AI_AGENT_ONBOARDING; do
+  ls docs/ 2>/dev/null | grep -qi "$d" && echo "  docs/$d: ok" || echo "  docs/$d: missing"
+done
+
+# 4. .agents/ home with agents/ commands/ skills/ + a docs catalog; .claude resolves
+for d in .agents/agents .agents/commands .agents/skills .agents/docs; do
+  test -d "$d" && echo "$d: ok" || echo "$d: FAIL"
+done
+[ -e .claude ] && echo ".claude resolves: ok" || echo ".claude resolves: FAIL"
+
+# 5. dwp-* commands are thin delegators (≤ ~30 lines, reference the skill)
+for f in .agents/commands/dwp-*.md; do
+  [ -f "$f" ] || continue
+  lines=$(wc -l < "$f")
+  grep -qi 'deepworkplan' "$f" && [ "$lines" -le 40 ] && echo "$(basename "$f"): thin ok" || echo "$(basename "$f"): CHECK ($lines lines)"
+done
+
+# 6. .dwp/ gitignored with plans/ + drafts/; tmp/ gitignored
+git check-ignore .dwp >/dev/null 2>&1 && echo ".dwp gitignored: ok" || echo ".dwp gitignored: FAIL"
+test -d .dwp/plans && test -d .dwp/drafts && echo ".dwp structure: ok" || echo ".dwp structure: FAIL"
+git check-ignore tmp >/dev/null 2>&1 && echo "tmp gitignored: ok" || echo "tmp gitignored: SHOULD"
+```
+
+Then, by reading rather than grepping:
+
+- **Real commands.** Open `AGENTS.md` and confirm the Quick Commands actually correspond to this repo (the real package manager, test, lint, and build commands). Flag any command that could not run here.
+- **Catalog matches disk.** Confirm `.agents/docs/` (the skills/agents catalog) lists exactly the skills, agents, and commands that exist under `.agents/` — no dead links, no missing entries.
+- **Skill resolvable.** Confirm the DeepWorkPlan skill is installed or referenced so its sub-skills can be invoked.
+
+## Plan checks (when verifying a plan)
+
+For each plan under `.dwp/plans/PLAN_{name}/`:
+
+- Every task file declares an explicit scope, **acceptance criteria**, and at least one **validation gate** (a runnable command or check).
+- `PROGRESS.md` exists and is updated, so the plan is resumable.
+- The two mandatory final tasks are present — Skills & Agents Discovery and the Executive Report.
+- Tasks re-anchor to the plan goal before executing.
+
+## Output
+
+Produce a concise report:
+
+```
+DeepWorkPlan conformance — {repo name}
+
+Repository
+  [x] AGENTS.md (real Quick Commands)
+  [x] CLAUDE.md -> AGENTS.md
+  [ ] docs/ — missing SECURITY.md
+  [x] .agents/ + catalog matches disk
+  [x] .dwp/ gitignored (plans/, drafts/)
+  [x] tmp/ gitignored
+  [x] skill resolvable
+
+Verdict: NOT CONFORMANT — 1 issue.
+Next: run /dwp-create "fix conformance gaps" to plan the remediation, then /dwp-execute.
+```
+
+End with one of: **CONFORMANT** (all MUST criteria pass) or **NOT CONFORMANT — N issue(s)**, listing each failure. If gaps exist, offer to capture the fixes as a Deep Work Plan with `/dwp-create` — do not fix them silently inside this read-only check.


### PR DESCRIPTION
# PR: feat — router Start-here + verify sub-skill + execute autonomous mode

**Repo:** `DailybotHQ/deepworkplan-skill`
**Base:** `main` ← **Head:** `feat/router-start-here`
**Create:** https://github.com/DailybotHQ/deepworkplan-skill/compare/main...feat/router-start-here?expand=1

**Title:**
```
feat: self-sufficient router, verify sub-skill, and autonomous execute
```

---

## Summary

Finalize the skill so any agent can take a repository from zero to fully
agent-pilotable — discover the skill, make the repo the harness, then create,
verify, and execute Deep Work Plans autonomously for hours. Three additions:

- **Router "Start here (first run)"** — make the skill a self-sufficient entry
  point. Until now the router only mapped intent → sub-skill; an agent that
  discovered/installed the skill (before ever seeing the website) had no in-skill
  cue to onboard. The router now mirrors `deepworkplan.com/init.md` locally
  (no network): if the repo isn't AI-first (no root `AGENTS.md` / no `.agents/`),
  read the local spec + adaptation rule, run the non-destructive `onboard` flow,
  verify, then plan/execute.

- **`verify` sub-skill (`/dwp-verify`)** — a read-only, objective conformance
  check. Reports pass/fail for the repository (AGENTS.md with real runnable
  commands, CLAUDE.md resolution, docs/ categories, `.agents/` catalog matching
  disk, thin `dwp-*` delegators, gitignored `.dwp/` + `tmp/`, resolvable skill)
  and for plans (every task has acceptance criteria + a validation gate,
  persisted progress, mandatory final tasks, re-anchoring). Wired into the router
  (routing row + Start-here step), and `onboard` now generates the `/dwp-verify`
  delegator (six `dwp-*` commands). Mirrors the website's `/spec` Conformance doc.

- **`execute` autonomous mode + context-window checkpointing** — make hours-long
  unattended runs explicit and safe: in `trust`/`auto`, loop
  task → validate → commit → update `PROGRESS.md` → next, stopping only on a
  failed gate, ambiguity, a blocking dependency, an out-of-scope/destructive
  action, or completion. State lives on disk so a plan survives a context-window
  reset; `resume` re-reads disk (never conversation memory) and re-anchors to the
  goal each task to prevent drift.

## Validation

- `python3 scripts/validate-frontmatter.py` → OK, all 12 SKILL.md
- `bats tests/` → 16 ok (1 skip: codex on PATH)

## Release / downstream

This is additive: a new sub-skill + router/onboard/execute docs → **minor bump
(v2.2.0)** via auto-release. After release, the deepworkplan-website pin
(`skills-lock.json`) is updated to 2.2.0 so the site's "eight sub-skills +
/dwp-verify" matches the published skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
