### PR TITLE
feat(onboard): expand preset catalog to 22 stacks + add OpenCode/Antigravity hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ Pick the path for your agent, clone, then run `setup.sh`:
 | GitHub Copilot | `~/.copilot/skills/deepworkplan/` |
 | Cline | `~/.cline/skills/deepworkplan/` |
 | Gemini CLI | `~/.gemini/skills/deepworkplan/` |
+| OpenCode | `~/.config/opencode/skills/deepworkplan/` |
+| Antigravity | `~/.antigravity/skills/deepworkplan/` |
 | OpenClaw | `<workspace>/skills/deepworkplan/` or `~/.openclaw/skills/` |
 
 ```bash

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -91,7 +91,7 @@ For users who don't want Node and prefer explicit control. The included
 git clone https://github.com/DailybotHQ/deepworkplan-skill.git ~/deepworkplan-skill
 cd ~/deepworkplan-skill
 ./setup.sh                 # auto-detect installed agents
-./setup.sh --host claude   # or: cursor, codex, windsurf, copilot, cline, gemini
+./setup.sh --host claude   # or: cursor, codex, windsurf, copilot, cline, gemini, opencode, antigravity
 ```
 
 `setup.sh` creates these symlinks for each detected agent:
@@ -143,6 +143,8 @@ Per-agent paths:
 | GitHub Copilot | `~/.copilot/skills/<dir>` |
 | Cline | `~/.cline/skills/<dir>` |
 | Gemini CLI | `~/.gemini/skills/<dir>` |
+| OpenCode | `~/.config/opencode/skills/<dir>` |
+| Antigravity | `~/.antigravity/skills/<dir>` |
 | OpenClaw | `<workspace>/skills/<dir>` or `~/.openclaw/skills/` |
 
 The runnable skill lives inside the clone at `skills/deepworkplan/`, and the

--- a/setup.sh
+++ b/setup.sh
@@ -40,7 +40,7 @@ while [ $# -gt 0 ]; do
       exec "$SCRIPT_DIR/scripts/verify-integrity.sh"
       ;;
     -h|--help)
-      echo "Usage: ./setup.sh [--host claude|cursor|codex|windsurf|copilot|cline|gemini|auto]"
+      echo "Usage: ./setup.sh [--host claude|cursor|codex|windsurf|copilot|cline|gemini|opencode|antigravity|auto]"
       echo "       ./setup.sh --verify"
       echo ""
       echo "Creates symlinks for the DeepWorkPlan pack and each sub-skill so your"
@@ -66,6 +66,8 @@ resolve_skills_dir() {
     copilot)  echo "$HOME/.copilot/skills" ;;
     cline)    echo "$HOME/.cline/skills" ;;
     gemini)   echo "$HOME/.gemini/skills" ;;
+    opencode) echo "$HOME/.config/opencode/skills" ;;
+    antigravity) echo "$HOME/.antigravity/skills" ;;
     *) echo "" ;;
   esac
 }
@@ -126,6 +128,8 @@ detect_agents() {
   [ -d "$HOME/.copilot" ]                  && found+=("copilot")
   [ -d "$HOME/.cline" ]                    && found+=("cline")
   [ -d "$HOME/.gemini" ]                   && found+=("gemini")
+  [ -d "$HOME/.config/opencode" ]          && found+=("opencode")
+  [ -d "$HOME/.antigravity" ]              && found+=("antigravity")
 
   # Deduplicate
   if [ ${#found[@]} -gt 0 ]; then

--- a/skills/deepworkplan/onboard/SKILL.md
+++ b/skills/deepworkplan/onboard/SKILL.md
@@ -44,9 +44,13 @@ work reliably without per-session human hand-holding.
 - [`../shared/dwp-paths.md`](../shared/dwp-paths.md) — the `.dwp/` output
   convention you scaffold in Phase 7.
 - [`presets/README.md`](presets/README.md) — the per-stack **reasoning guides**
-  (Django, Vue/Vite, Astro/Svelte, Node/TS service, Python package/CLI, generic
-  fallback) and the orchestrator-hub note. Read the matching preset in Phase 1
-  and use it in Phases 3–6. **Presets are reasoning aids, not templates.**
+  spanning backend/API (Django, FastAPI, Rails, Spring Boot, Laravel, NestJS),
+  frontend (Vue/Vite, Next.js, SvelteKit, Nuxt, Angular, Astro/Svelte), mobile
+  (React Native, Flutter, Swift/iOS), and systems/infra (Go, Rust, Terraform,
+  TypeScript Lambda, Node/TS service, Python package/CLI), plus a `generic`
+  fallback and the orchestrator-hub note. See `presets/README.md` for the full
+  index. Read the matching preset in Phase 1 and use it in Phases 3–6.
+  **Presets are reasoning aids, not templates.**
 - [`../guide/GUIDE.md`](../guide/GUIDE.md) — the DWP methodology you reference
   when wiring the skill and (for hubs) the orchestrator/child-DWP capability.
 
@@ -158,9 +162,10 @@ Detect, by reading actual files (not by habit):
   commit-message style (`git log`). **Carry these forward**; do not override a
   working convention with a generic one.
 
-Then **load the matching preset** from `presets/` (Django, Vue/Vite,
-Astro/Svelte, Node/TS service, Python package/CLI, or `generic` if nothing
-matches). Use it as a **reasoning checklist**, and explicitly verify each preset
+Then **load the matching preset** from `presets/` (one per common stack across
+backend, frontend, mobile, and systems/infra — see `presets/README.md` for the
+full index — or `generic` if nothing matches). Use it as a **reasoning
+checklist**, and explicitly verify each preset
 assumption against what you actually found — **detected reality wins over preset
 assumptions**.
 

--- a/skills/deepworkplan/onboard/presets/README.md
+++ b/skills/deepworkplan/onboard/presets/README.md
@@ -29,10 +29,26 @@ guide per common stack, plus a `generic` fallback for anything unrecognized.
 | Guide | Stack | Identify by |
 |-------|-------|-------------|
 | [`django.md`](django.md) | Django / DRF (Python) | `manage.py`, `settings.py`, `poetry`/`pip` |
-| [`vue-vite.md`](vue-vite.md) | Vue + Vite (TypeScript) | `vite.config.*`, `vue` in deps |
-| [`astro-svelte.md`](astro-svelte.md) | Astro (+ Svelte) static/SSR site | `astro.config.*`, `.astro`/`.svelte` files |
-| [`node-ts-service.md`](node-ts-service.md) | Node/TypeScript service (Express/Fastify/Lambda) | server framework imports, `serverless.yml`/handlers |
+| [`fastapi.md`](fastapi.md) | FastAPI (Python) | `fastapi`/`uvicorn` in deps, async routes, `APIRouter` |
 | [`python-package-cli.md`](python-package-cli.md) | Python package / CLI | `[project.scripts]` / `console_scripts`, Click/Typer |
+| [`node-ts-service.md`](node-ts-service.md) | Node/TypeScript service (Express/Fastify/Lambda) | server framework imports, `serverless.yml`/handlers |
+| [`nestjs.md`](nestjs.md) | NestJS (TypeScript) | `nest-cli.json`, `@Module`/`@Controller` decorators |
+| [`ts-lambda.md`](ts-lambda.md) | TypeScript Lambda (Serverless) | `serverless.yml` / SAM `template.yaml` / CDK, handlers |
+| [`spring-boot.md`](spring-boot.md) | Spring Boot (Java/Kotlin) | `pom.xml`/`build.gradle`, `@SpringBootApplication` |
+| [`rails.md`](rails.md) | Ruby on Rails | `Gemfile`, `bin/rails`, `app/{models,controllers}` |
+| [`laravel.md`](laravel.md) | Laravel (PHP) | `composer.json`, `artisan`, `app/Http/Controllers` |
+| [`vue-vite.md`](vue-vite.md) | Vue + Vite (TypeScript) | `vite.config.*`, `vue` in deps |
+| [`nuxt.md`](nuxt.md) | Nuxt (Vue) | `nuxt.config.*`, `server/api`, Nitro |
+| [`nextjs.md`](nextjs.md) | Next.js (React) | `next.config.*`, `app/` or `pages/` router |
+| [`sveltekit.md`](sveltekit.md) | SvelteKit | `svelte.config.js`, `src/routes/+page.svelte` |
+| [`angular.md`](angular.md) | Angular | `angular.json`, `@Component`/`@NgModule` |
+| [`astro-svelte.md`](astro-svelte.md) | Astro (+ Svelte) static/SSR site | `astro.config.*`, `.astro`/`.svelte` files |
+| [`react-native.md`](react-native.md) | React Native (Expo) | `app.json`/`app.config.*`, `expo`/`react-native` deps |
+| [`flutter.md`](flutter.md) | Flutter (Dart) | `pubspec.yaml`, `lib/main.dart` |
+| [`swift-ios.md`](swift-ios.md) | Swift / iOS | `*.xcodeproj`/`*.xcworkspace`, `Package.swift`, XCTest |
+| [`go.md`](go.md) | Go (modules) | `go.mod`, `package main`, `cmd/`/`internal/` |
+| [`rust.md`](rust.md) | Rust (Cargo) | `Cargo.toml`, `src/main.rs`/`lib.rs` |
+| [`terraform.md`](terraform.md) | Terraform / IaC | `*.tf`, `main.tf`/`variables.tf`/`outputs.tf` |
 | [`generic.md`](generic.md) | **Fallback** — any unrecognized stack | none of the above match |
 
 ## Archetype note (orchestrator hub)

--- a/skills/deepworkplan/onboard/presets/angular.md
+++ b/skills/deepworkplan/onboard/presets/angular.md
@@ -1,0 +1,66 @@
+# Preset — Angular (TypeScript)
+
+> Reasoning aid, not a template. Verify against the live repo; detected reality
+> wins. Capture the **real** validation command, not the example below.
+
+## Signals that identify this stack
+
+- `angular.json` at the repo root and `@angular/core` in `package.json`
+  `dependencies` (Angular version → `@angular/*@^N`).
+- `src/app/` with components decorated `@Component({ selector, template/
+  templateUrl, styleUrls })`, and either `@NgModule` declarations
+  (`app.module.ts`) or **standalone components** (`standalone: true`,
+  `bootstrapApplication`, `app.config.ts`). **Confirm which the app uses.**
+- Services decorated `@Injectable({ providedIn: 'root' })`, RxJS (`rxjs` in
+  deps, `Observable`/`Subject`/`pipe`), and `@angular/router` for routing.
+- `@angular/cli` / `ng` available; `tsconfig.json` plus `tsconfig.app.json` /
+  `tsconfig.spec.json` splits.
+- Package manager from the lockfile: `pnpm-lock.yaml` → pnpm, `yarn.lock` →
+  yarn, `package-lock.json` → npm. **Infer from the lockfile present.**
+- Layout: `src/app/` with feature folders, `components/`, `services/`, `models/`,
+  `guards/`, `*.module.ts`/`*.routes.ts`; possibly an Nx workspace (`nx.json`,
+  `project.json`, `libs/`/`apps/`).
+
+## What to look for in recon
+
+- The **real** test runner: Karma + Jasmine (`karma.conf.js`, `*.spec.ts`,
+  `ng test`) vs Jest (`jest.config.*`, `@angular-builders/jest` or `jest-preset-
+  angular`, `*.spec.ts`). **Confirm which from the config that exists.**
+- The **real** lint gate: `ng lint` backed by `@angular-eslint` (`.eslintrc` /
+  `eslint.config.js`), and any Prettier step. Capture verbatim.
+- The **real** build: `ng build` (and `ng build --configuration production`),
+  and whether SSR/`@angular/ssr` or `@angular/universal` is in play.
+- NgModules vs standalone: drives whether new features need a module entry or a
+  `providers`/`imports` array on the component/route.
+- State management if present: NgRx (`@ngrx/store`, effects, selectors),
+  signals (`signal()`, `computed()`), or plain services-with-subjects.
+
+## Stack-specific skills/agents/commands to generate
+
+- Skills: `component` (component + template + spec), `service` (injectable +
+  spec), `module` or `standalone-feature` (depending on the app style),
+  `guard`/`resolver`, and `ngrx-feature` (store + effects + selectors) if NgRx
+  is present.
+- Agents: baseline + a `component-author` / `frontend-reviewer` persona aware of
+  change detection (OnPush), the smart-vs-presentational split, and RxJS
+  subscription/teardown hygiene.
+- Commands: the five DWP commands + `code-review`, `pr`, `commit`.
+
+## Doc emphases
+
+- `ARCHITECTURE.md` — module/standalone structure, routing, DI tree, RxJS data
+  flow, state management (NgRx/signals), HTTP/interceptor layer.
+- `STANDARDS.md` — component/service conventions, OnPush change detection,
+  subscription teardown (`takeUntilDestroyed`/`async` pipe), smart-vs-dumb split.
+- `TESTING_GUIDE.md` — Karma/Jasmine vs Jest, `TestBed` setup, `HttpTestingController`,
+  the real `*.spec.ts` pattern, how to scope one feature's tests.
+- Per-module docs: one per feature module / standalone feature (its components,
+  services, routes, guards).
+
+## Typical validation command (FIND the real one)
+
+Commonly `ng lint && ng test --watch=false --browsers=ChromeHeadless && ng
+build`, or wrapped `package.json` scripts (`npm run lint && npm run test:ci &&
+npm run build`). **Do not assume** the package manager, the test runner, or the
+script names — read `angular.json`, `package.json`, and CI and capture the exact
+commands.

--- a/skills/deepworkplan/onboard/presets/fastapi.md
+++ b/skills/deepworkplan/onboard/presets/fastapi.md
@@ -1,0 +1,72 @@
+# Preset — FastAPI (Python)
+
+> Reasoning aid, not a template. Verify every assumption against the live repo;
+> detected reality wins. Capture the **real** validation command, not the
+> example below.
+
+## Signals that identify this stack
+
+- `fastapi` in `pyproject.toml` / `requirements.txt`, plus an ASGI server:
+  `uvicorn`, or `gunicorn` with `uvicorn.workers.UvicornWorker`.
+- An application factory or module-level instance: `app = FastAPI(...)`, often
+  in `app/main.py` / `main.py` / `src/<pkg>/main.py`.
+- `APIRouter` modules wired in via `app.include_router(...)`, `async def` (and
+  some `def`) path operations decorated with `@router.get/post/...`.
+- Pydantic models for request/response schemas (Pydantic v1 vs v2 matters), and
+  `pydantic-settings`/`BaseSettings` for configuration.
+- Dependency injection via `Depends(...)`; common deps for DB sessions, auth,
+  and pagination.
+- Package manager from the lockfile: `poetry.lock` → Poetry, `uv.lock` → uv,
+  `Pipfile.lock` → Pipenv, bare `requirements.txt` → pip/venv. **Infer from the
+  lockfile present.**
+- Frequently paired with SQLAlchemy + Alembic (`alembic.ini`, `migrations/` or
+  `alembic/`), or an async ORM (SQLModel, Tortoise). Often containerized
+  (`Dockerfile`, `docker-compose.yml`).
+
+## What to look for in recon
+
+- The **real** test runner: almost always `pytest` (`pytest.ini` /
+  `pyproject [tool.pytest.ini_options]`), driving endpoints through Starlette's
+  `TestClient` or async `httpx.AsyncClient` with `ASGITransport`. Confirm the
+  test layout (`tests/`, `test_*.py`) and any `conftest.py` fixtures.
+- The **real** lint/format/typecheck gate: `ruff` (lint + format), `black`,
+  `isort`, `mypy`/`pyright` — and whether it's wrapped in a Makefile/script and
+  whether it **runs inside Docker** (flag it if so).
+- The Pydantic major version (v1 vs v2) — it changes validators, config, and
+  serialization patterns the generated skills must follow.
+- Sync vs async surface: blocking I/O inside `async def` handlers is a hazard;
+  note the DB driver (async vs sync) and the event-loop discipline.
+- Router composition (`include_router`, prefixes, tags), the settings/secrets
+  layout (`.env`, `BaseSettings`), and the run command (`uvicorn app.main:app`).
+- Migration workflow if Alembic is present (`alembic revision --autogenerate`,
+  `alembic upgrade head`) and whether it runs in the container.
+
+## Stack-specific skills/agents/commands to generate
+
+- Skills: `router-add` (an `APIRouter` module + handlers + `include_router`
+  wiring), `schema` (Pydantic request/response models), `dependency` (a
+  `Depends` provider — auth, DB session, pagination), `endpoint` (path operation
+  + schema + test), optionally `migration` (Alembic revision) if SQLAlchemy is
+  present.
+- Agents: baseline roles + an `api-reviewer` / `schema-author` persona aware of
+  Pydantic validation, response models, and async/blocking hazards.
+- Commands: the five DWP commands + `code-review`, `pr`, `commit`.
+
+## Doc emphases
+
+- `ARCHITECTURE.md` — app assembly (`include_router`), request → dependency →
+  handler → response-model flow, async vs sync boundaries, DB/session lifecycle.
+- `TESTING_GUIDE.md` — `pytest` + `TestClient`/`httpx`, async fixtures, how to
+  override dependencies (`app.dependency_overrides`) and scope one router's
+  tests.
+- `SECURITY.md` — auth scheme (OAuth2/JWT, API keys), `BaseSettings`/secrets
+  handling, input validation via Pydantic, CORS.
+- Per-module docs: one per router/feature (its schemas, dependencies,
+  endpoints).
+
+## Typical validation command (FIND the real one)
+
+Often `ruff check && mypy && pytest`, or a wrapped/Dockerized gate (e.g. `make
+check`, or commands run *inside* the container). **Do not assume** the package
+manager or script names — read the Makefile/`pyproject.toml`/CI and capture the
+exact command, flagging that it runs inside Docker if so.

--- a/skills/deepworkplan/onboard/presets/flutter.md
+++ b/skills/deepworkplan/onboard/presets/flutter.md
@@ -1,0 +1,64 @@
+# Preset — Flutter (Dart)
+
+> Reasoning aid, not a template. Verify against the live repo; detected reality
+> wins. Capture the **real** validation command, not the example below.
+
+## Signals that identify this stack
+
+- `pubspec.yaml` at the repo root with `flutter:` under `dependencies` and an
+  `sdk: flutter` line; `pubspec.lock` pins the resolved versions.
+- `lib/main.dart` with a `void main() => runApp(...)` entry and a root widget
+  (`MaterialApp`/`CupertinoApp`).
+- Widgets extending `StatelessWidget`/`StatefulWidget`; `BuildContext`,
+  `build()` methods.
+- `analysis_options.yaml` (often `include: package:flutter_lints/flutter.yaml`
+  or `package:lints/recommended.yaml`) — the analyzer/lint config.
+- `test/` with `*_test.dart` files using `flutter_test` (`testWidgets`,
+  `WidgetTester`); possibly `integration_test/` and `test/golden/` golden files.
+- Platform folders: `android/`, `ios/`, and optionally `web/`, `macos/`,
+  `linux/`, `windows/` (multi-platform target).
+
+## What to look for in recon
+
+- The **real** test command: `flutter test` (unit/widget) and any
+  `flutter test integration_test/` or golden-test step. Test naming is
+  `*_test.dart`. Capture verbatim.
+- The **real** static-analysis gate: `flutter analyze` (or `dart analyze`)
+  driven by `analysis_options.yaml`, plus `dart format --set-exit-if-changed .`.
+- The **real** build target(s): `flutter build apk`/`appbundle`/`ipa`/`web` —
+  which platforms ship, and any flavor/`--dart-define` config.
+- **State management** if present: Provider (`provider`), Riverpod
+  (`flutter_riverpod`, `@riverpod`), or Bloc (`flutter_bloc`, `Cubit`/`Bloc`).
+  **Confirm which — it shapes the generated skills.**
+- **Code generation** if present: `build_runner` with `json_serializable`,
+  `freezed`, `riverpod_generator`, or `*.g.dart`/`*.freezed.dart` files →
+  a `dart run build_runner build --delete-conflicting-outputs` step.
+
+## Stack-specific skills/agents/commands to generate
+
+- Skills: `widget` (widget + widget test), `screen`/`page` (route + screen),
+  `model` (data class + `fromJson`/`toJson`, with codegen if `json_serializable`),
+  and a state-shaped skill matching the library — `provider`/`riverpod-provider`/
+  `bloc-feature`.
+- Agents: baseline + a `widget-author` / `frontend-reviewer` persona aware of
+  the widget tree, rebuild/`const` performance, and the chosen state pattern.
+- Commands: the five DWP commands + `code-review`, `pr`, `commit`.
+
+## Doc emphases
+
+- `ARCHITECTURE.md` — widget/screen structure under `lib/`, the state-management
+  approach, the data/repository layer, navigation, platform targets.
+- `STANDARDS.md` — widget conventions (`const` constructors, composition over
+  inheritance), file/feature layout, the analyzer ruleset.
+- `TESTING_GUIDE.md` — `flutter_test` unit/widget tests, `WidgetTester` pumping,
+  golden tests if used, the real `*_test.dart` pattern, mocking.
+- Per-module docs: per feature folder under `lib/` (its widgets, screens,
+  models, providers/blocs).
+
+## Typical validation command (FIND the real one)
+
+Commonly `flutter analyze && dart format --set-exit-if-changed . && flutter
+test`, plus a `dart run build_runner build` step before tests if code
+generation is used. **Do not assume** the state library, whether codegen runs,
+or which platforms build — read `pubspec.yaml`, `analysis_options.yaml`, and CI
+and capture the exact commands.

--- a/skills/deepworkplan/onboard/presets/go.md
+++ b/skills/deepworkplan/onboard/presets/go.md
@@ -1,0 +1,57 @@
+# Preset — Go (modules)
+
+> Reasoning aid, not a template. Verify every assumption against the live repo;
+> detected reality wins. Capture the **real** validation command, not the
+> example below.
+
+## Signals that identify this stack
+
+- `go.mod` and `go.sum` at the repo root; the first line of `go.mod` is the
+  module path, followed by the `go` directive (language version) and `require`
+  blocks.
+- A `package main` with `func main()` as the binary entry point — frequently
+  under `cmd/<binary>/main.go` when there are several binaries.
+- Idiomatic layout: `cmd/` (binaries), `internal/` (private packages the module
+  alone can import), `pkg/` (exported reusable packages), plus domain packages.
+- Multi-module repos carry more than one `go.mod` (e.g. a `go.work` workspace or
+  nested modules). **Infer from what's present.**
+- Optional: a `Makefile`, a `vendor/` directory (vendored deps), `.golangci.yml`,
+  and a `Dockerfile` for containerized builds.
+
+## What to look for in recon
+
+- The **real** test command: `go test ./...` (often with `-race`, `-cover`, or
+  `-count=1`). Tests are table-driven `*_test.go` files **beside** the code they
+  test; check for `testdata/` fixtures and any `TestMain`.
+- The **real** lint/vet gate: `go vet ./...`, `golangci-lint run` (read
+  `.golangci.yml` for enabled linters), and a format check (`gofmt -l .` or
+  `goimports`). Confirm which one CI enforces.
+- The **real** build: `go build ./...`, plus any release wiring (`-ldflags`,
+  `CGO_ENABLED`, cross-compilation via `GOOS`/`GOARCH`).
+- The module path, exported vs `internal/` boundaries, and where binaries live.
+
+## Stack-specific skills/agents/commands to generate
+
+- Skills: `package-add` (new package + table-driven test), `handler` (HTTP
+  handler + test) if it's a service, `cmd-add` (new binary under `cmd/`),
+  optionally `interface` (define an interface + mock) and `error-wrap`.
+- Agents: baseline roles + an `api-reviewer` / `concurrency-reviewer` persona
+  aware of goroutine/channel safety and `context.Context` propagation.
+- Commands: the five DWP commands + `code-review`, `pr`, `commit`.
+
+## Doc emphases
+
+- `ARCHITECTURE.md` — package boundaries (`cmd`/`internal`/`pkg`), interface
+  seams, concurrency model (goroutines/channels/`context`), error-handling
+  conventions (wrapping with `%w`).
+- `TESTING_GUIDE.md` — table-driven tests, `testdata/` fixtures, subtests
+  (`t.Run`), how to scope a single package (`go test ./path/...`).
+- `SECURITY.md` — input validation, secrets handling, dependency hygiene
+  (`govulncheck`), the sensitive-data boundary.
+- Per-module docs: one per significant package or `cmd/` binary.
+
+## Typical validation command (FIND the real one)
+
+Often `gofmt -l . && go vet ./... && golangci-lint run && go test -race ./...`,
+with a separate `go build ./...`. **Do not assume** the lint tool or test flags
+— read the `Makefile`/`.golangci.yml`/CI and capture the exact command.

--- a/skills/deepworkplan/onboard/presets/laravel.md
+++ b/skills/deepworkplan/onboard/presets/laravel.md
@@ -1,0 +1,65 @@
+# Preset — Laravel (PHP)
+
+> Reasoning aid, not a template. Verify every assumption against the live repo;
+> detected reality wins. Capture the **real** validation command, not the
+> example below.
+
+## Signals that identify this stack
+
+- `composer.json` with `laravel/framework` in `require`, and an `artisan`
+  console entrypoint at the repo root.
+- App layout under `app/`: `Models/`, `Http/Controllers/`, `Http/Middleware/`,
+  `Providers/`, plus `config/`, `database/migrations/`, `database/seeders/`,
+  `resources/`, and `routes/`.
+- Routing in `routes/web.php` (session/web) and `routes/api.php` (stateless
+  API); console routes in `routes/console.php`.
+- Eloquent ORM models, migrations as timestamped classes under
+  `database/migrations/`, factories/seeders for test data.
+- Frequently containerized via **Laravel Sail**: look for `docker-compose.yml`,
+  a `vendor/bin/sail` wrapper, and MySQL/Postgres/Redis services.
+- Config and **secrets** in `.env` (driven by `config/*.php` reading `env()`);
+  `.env.example` documents the expected keys.
+
+## What to look for in recon
+
+- The **real** test runner: `php artisan test` (wraps PHPUnit/Pest), bare
+  `vendor/bin/phpunit`, or `vendor/bin/pest`. Check `phpunit.xml` and whether
+  `pestphp/pest` is in `composer.json`. Test layout is commonly
+  `tests/Feature/` and `tests/Unit/`.
+- The **real** lint/format/static-analysis gate: `vendor/bin/pint` (Laravel
+  Pint), PHP-CS-Fixer, and `vendor/bin/phpstan` / Larastan. Confirm which are
+  wired and whether a composer script (`composer test`, `composer lint`) wraps
+  them.
+- Migration workflow (`php artisan migrate`, `migrate:fresh --seed`) and whether
+  it runs inside Sail/Docker.
+- Whether queues/jobs (`app/Jobs/`), events/listeners, scheduled tasks
+  (`app/Console/Kernel.php` schedule), or Livewire/Inertia front-ends are present.
+
+## Stack-specific skills/agents/commands to generate
+
+- Skills: `model` (Eloquent model + migration + factory), `migration`
+  (make/apply migrations safely), `controller` (controller + route + request
+  validation), `artisan-command` (console command), optionally `job`/`queue`
+  and `eloquent-relation` if those patterns are present.
+- Agents: baseline roles + a `migration-author` / `db-reviewer` persona aware
+  of migration reversibility and mass-assignment/`$fillable` safety.
+- Commands: the five DWP commands + `code-review`, `pr`, `commit`.
+
+## Doc emphases
+
+- `ARCHITECTURE.md` — request → route → middleware → controller → Eloquent flow,
+  service/repository layering, queues/events, caching/Redis, the DB.
+- `TESTING_GUIDE.md` — PHPUnit vs Pest, feature vs unit tests, factories and
+  database refresh strategy (`RefreshDatabase`), how to scope a single test.
+- `SECURITY.md` — `.env`/config secrets handling, auth model (sessions,
+  Sanctum, Passport), mass-assignment and validation boundaries, CSRF.
+- Per-module docs: one per bounded area (its models, controllers, routes, jobs,
+  policies).
+
+## Typical validation command (FIND the real one)
+
+Often `php artisan test` plus `vendor/bin/pint --test` and/or
+`vendor/bin/phpstan analyse`, sometimes wrapped in a composer script and run
+**inside Sail** (`./vendor/bin/sail test`). **Do not assume** — read
+`composer.json` scripts, `phpunit.xml`, and CI, and capture the exact command,
+flagging if it runs inside Docker.

--- a/skills/deepworkplan/onboard/presets/nestjs.md
+++ b/skills/deepworkplan/onboard/presets/nestjs.md
@@ -1,0 +1,65 @@
+# Preset — NestJS (TypeScript)
+
+> Reasoning aid, not a template. Verify every assumption against the live repo;
+> detected reality wins. Capture the **real** validation command, not the
+> example below.
+
+## Signals that identify this stack
+
+- `nest-cli.json` at the repo root and `@nestjs/core`, `@nestjs/common` in
+  `package.json` deps; usually `reflect-metadata` and `rxjs`.
+- A bootstrap `main.ts` calling `NestFactory.create(AppModule)`; a root
+  `app.module.ts`.
+- The decorator + DI model: `@Module`, `@Controller`, `@Injectable`, plus
+  `@Get/@Post/...` route decorators and constructor injection.
+- Feature folders, each with `*.module.ts`, `*.controller.ts`, `*.service.ts`,
+  and `dto/` (request/response DTOs, often `class-validator`/`class-transformer`).
+- Cross-cutting providers: guards, pipes (`ValidationPipe`), interceptors,
+  filters, and `@nestjs/config` for configuration.
+- Package manager from the lockfile (`pnpm-lock.yaml` → pnpm, `yarn.lock` →
+  yarn, `package-lock.json` → npm). **Infer from what's present.**
+- Common companions: TypeORM/Prisma/Mongoose, `@nestjs/swagger`, microservices
+  (`@nestjs/microservices`), or GraphQL (`@nestjs/graphql`).
+
+## What to look for in recon
+
+- The **real** scripts in `package.json`: `test` (Jest unit), `test:e2e` (Jest
+  via `test/jest-e2e.json`), `test:cov`, `lint` (ESLint), `build` (`nest build`
+  / `tsc`), and `start:dev`. Capture them verbatim.
+- Test convention: unit tests are `*.spec.ts` co-located with sources; e2e tests
+  are `*.e2e-spec.ts` under `test/`, using `@nestjs/testing`'s
+  `Test.createTestingModule(...)` and supertest.
+- Module graph: how feature modules import/export providers and are wired into
+  `AppModule`; which providers are global.
+- Validation/serialization strategy: a global `ValidationPipe`, DTOs with
+  `class-validator` decorators, and any interceptors/serializers.
+- The ORM/data layer and migration workflow (TypeORM migrations vs Prisma
+  `migrate`), and where config/secrets live (`@nestjs/config`, `.env`).
+
+## Stack-specific skills/agents/commands to generate
+
+- Skills: `module-add` (feature module scaffold + wiring into `AppModule`),
+  `controller` (controller + route handlers + spec), `provider`/`service`
+  (injectable service + spec), `dto` (request/response DTO with validation),
+  optionally `guard`/`pipe`/`interceptor` and `migration` if an ORM is present.
+- Agents: baseline roles + an `api-reviewer` / `module-author` persona aware of
+  DI scope, DTO validation, and module boundaries.
+- Commands: the five DWP commands + `code-review`, `pr`, `commit`.
+
+## Doc emphases
+
+- `ARCHITECTURE.md` — module graph and DI, request → guard → pipe → controller →
+  service → repository flow, interceptors/filters, transport (HTTP/microservice/
+  GraphQL).
+- `TESTING_GUIDE.md` — Jest unit `*.spec.ts` with `Test.createTestingModule` and
+  provider mocking, e2e `*.e2e-spec.ts` with supertest, how to scope one
+  module's tests.
+- `SECURITY.md` — auth guards/strategies (`@nestjs/passport`, JWT), global
+  `ValidationPipe`, secrets via `@nestjs/config`.
+- Per-module docs: one per feature module (its controllers, providers, DTOs).
+
+## Typical validation command (FIND the real one)
+
+Commonly `<pm> run lint && <pm> test && <pm> run build` (e.g. `pnpm`/`npm`),
+sometimes with `test:e2e`. **Do not assume the package manager or script
+names** — read `package.json`/CI and capture the exact commands.

--- a/skills/deepworkplan/onboard/presets/nextjs.md
+++ b/skills/deepworkplan/onboard/presets/nextjs.md
@@ -1,0 +1,68 @@
+# Preset — Next.js (React)
+
+> Reasoning aid, not a template. Verify against the live repo; detected reality
+> wins. Capture the **real** validation command, not the example below.
+
+## Signals that identify this stack
+
+- `next` and `react` in `package.json` `dependencies`, plus a
+  `next.config.js` / `next.config.mjs` / `next.config.ts` at the repo root.
+- **Router detection (decisive):** an `app/` directory → **App Router**
+  (Server Components by default, `'use client'` for Client Components, nested
+  `layout.tsx`/`page.tsx`, `route.ts` route handlers, server actions); a
+  `pages/` directory → **Pages Router** (`pages/_app`, `getServerSideProps`/
+  `getStaticProps`, `pages/api/*` API routes). Some repos run **both** during a
+  migration — note it.
+- Package manager from the lockfile: `pnpm-lock.yaml` → pnpm, `yarn.lock` →
+  yarn, `package-lock.json` → npm. **Infer from the lockfile present.**
+- Layout: `src/` or root-level `app/`/`pages/`, `components/`, `lib/`,
+  `public/`; TypeScript via `tsconfig.json`; styling via Tailwind, CSS Modules,
+  or styled-components.
+
+## What to look for in recon
+
+- The **real** `package.json` scripts: `dev`, `build` (`next build`),
+  `start`, `lint` (`next lint` / `eslint`), and the test command. Capture them
+  verbatim.
+- Lint config: `eslint-config-next` with `next/core-web-vitals` (the canonical
+  Next ESLint preset). Confirm whether it's `next lint` or a direct `eslint`
+  invocation, and whether Biome is used instead.
+- Test convention: unit/component via **Jest** (`jest.config`) or **Vitest**
+  (`vitest.config`) with Testing Library; end-to-end via **Playwright**
+  (`playwright.config.ts`) or **Cypress** (`cypress/`). Note `*.test.tsx` /
+  `*.spec.tsx` naming and where tests live.
+- Data layer: server actions, route handlers (`app/**/route.ts`), or
+  `pages/api/*`; where env/config and secrets live (`.env.local`,
+  `NEXT_PUBLIC_*` vs server-only vars — the boundary matters).
+- Rendering strategy (static/SSG, SSR, ISR, streaming) — it shapes
+  `PERFORMANCE.md`.
+
+## Stack-specific skills/agents/commands to generate
+
+- Skills (App Router): `page`/`route` (segment `page.tsx` + `layout.tsx`),
+  `server-component`, `client-component`, `route-handler` (`route.ts` +
+  test), `server-action`. Skills (Pages Router): `page` (`pages/*` +
+  data-fetching fn), `api-route` (`pages/api/*` + test), `component`.
+- Agents: baseline + a `frontend-reviewer` persona aware of the Server vs
+  Client Component boundary, the `NEXT_PUBLIC_*` env boundary, and Core Web
+  Vitals.
+- Commands: the five DWP commands + `code-review`, `pr`, `commit`.
+
+## Doc emphases
+
+- `ARCHITECTURE.md` — router model (App vs Pages), Server/Client Component
+  split, data fetching (server actions / route handlers / `getServerSideProps`),
+  rendering/caching strategy.
+- `STANDARDS.md` — component conventions, the `'use client'` boundary,
+  props/typing, file-colocation rules.
+- `TESTING_GUIDE.md` — Jest/Vitest + Testing Library patterns, Playwright/
+  Cypress e2e flow, the real `*.test.tsx`/`*.spec.tsx` pattern, coverage target.
+- `PERFORMANCE.md` — rendering strategy, bundle/Core Web Vitals budgets,
+  `next/image` and font optimization.
+
+## Typical validation command (FIND the real one)
+
+Commonly `pnpm run lint && pnpm test && pnpm run build` (or npm/yarn), with
+`next build` as the build gate and a separate e2e job. **Do not assume the
+package manager, the router, or script names** — read `package.json`, the
+config files, and CI, and capture the exact commands.

--- a/skills/deepworkplan/onboard/presets/nuxt.md
+++ b/skills/deepworkplan/onboard/presets/nuxt.md
@@ -1,0 +1,67 @@
+# Preset — Nuxt (Vue)
+
+> Reasoning aid, not a template. Verify against the live repo; detected reality
+> wins. Capture the **real** validation command, not the example below.
+
+## Signals that identify this stack
+
+- `nuxt` in `package.json` `dependencies` and a `nuxt.config.ts` at the repo
+  root (Nuxt 3+; Vue 3 + Vite + the **Nitro** server engine under the hood).
+- An `app.vue` entrypoint; file-based routing under `pages/` (with `[id].vue`
+  dynamic segments and `[...slug].vue` catch-alls) and `layouts/`.
+- Server layer under `server/`: `server/api/*` (Nitro route handlers, e.g.
+  `server/api/users.get.ts`), `server/routes/`, `server/middleware/`,
+  `server/utils/`.
+- Auto-imported `composables/`, `components/`, `utils/`, and `stores/` (Pinia
+  via `@pinia/nuxt`); `plugins/`, `middleware/` (route middleware),
+  `assets/`/`public/`.
+- Package manager from the lockfile: `pnpm-lock.yaml` → pnpm, `yarn.lock` →
+  yarn, `package-lock.json` → npm. **Infer from the lockfile present.**
+
+## What to look for in recon
+
+- The **real** `package.json` scripts: `dev`, `build` (`nuxt build`),
+  `generate` (`nuxt generate`, for static), `preview`, `typecheck`
+  (`nuxi typecheck` / `nuxt typecheck`), `lint` (`eslint`, often via
+  `@nuxt/eslint`), and the test command. Capture them verbatim.
+- Test convention: **Vitest** with **`@nuxt/test-utils`** (the official Nuxt
+  test harness — `defineVitestConfig`, `mountSuspended`, `setup` for e2e). Note
+  `*.test.ts`/`*.spec.ts` naming, and whether component vs Nuxt-runtime tests
+  are split.
+- Rendering mode in `nuxt.config.ts`: universal SSR (default), SSG
+  (`nuxt generate` / `nitro.prerender`), SPA (`ssr: false`), or hybrid
+  per-route `routeRules` — this shapes `PERFORMANCE.md` and the deploy target.
+- Data fetching (`useFetch`, `useAsyncData`, `$fetch`), `runtimeConfig` and
+  where **secrets** live (server-only `runtimeConfig` vs `public`, `.env`,
+  `NUXT_*` env vars — the boundary matters).
+- Modules enabled in `nuxt.config.ts` (`@nuxt/content`, `@pinia/nuxt`,
+  `@nuxtjs/i18n`, etc.) — they add conventions and directories.
+
+## Stack-specific skills/agents/commands to generate
+
+- Skills: `page`/`route` (`pages/*.vue` + `definePageMeta` + data fetching),
+  `server-route` (`server/api/*` Nitro handler + test), `composable`
+  (auto-imported composition fn), `component` (auto-imported SFC + test),
+  optionally `store-module` (Pinia) and `route-middleware`.
+- Agents: baseline + a `frontend-reviewer` persona aware of auto-imports, the
+  server-vs-client boundary, and the `runtimeConfig` public/private split.
+- Commands: the five DWP commands + `code-review`, `pr`, `commit`.
+
+## Doc emphases
+
+- `ARCHITECTURE.md` — pages/layouts routing, the Nitro `server/api` layer,
+  composables and auto-imports, data fetching, rendering mode and `routeRules`.
+- `STANDARDS.md` — SFC + Composition API conventions, auto-import expectations,
+  composable naming (`useX`), props/events typing.
+- `TESTING_GUIDE.md` — Vitest + `@nuxt/test-utils` patterns (`mountSuspended`,
+  runtime vs e2e setup), the real `*.test.ts`/`*.spec.ts` pattern, coverage
+  target.
+- `PERFORMANCE.md` — SSR vs SSG vs hybrid, payload/hydration cost, the deploy
+  preset/target, asset budgets.
+
+## Typical validation command (FIND the real one)
+
+Commonly `pnpm run lint && pnpm run typecheck && pnpm test && pnpm run build`
+(or npm/yarn), where typecheck is `nuxi typecheck` and build is `nuxt build`.
+**Do not assume the package manager or script names** — read `package.json`,
+`nuxt.config.ts`, and CI, and capture the exact commands.

--- a/skills/deepworkplan/onboard/presets/rails.md
+++ b/skills/deepworkplan/onboard/presets/rails.md
@@ -1,0 +1,62 @@
+# Preset — Ruby on Rails (Ruby)
+
+> Reasoning aid, not a template. Verify every assumption against the live repo;
+> detected reality wins. Capture the **real** validation command, not the
+> example below.
+
+## Signals that identify this stack
+
+- A `Gemfile` declaring `rails` (and `Gemfile.lock` pinning it), `bin/rails` and
+  `bin/rake` executables, and `config/application.rb` requiring `rails/all`.
+- The MVC layout under `app/`: `app/models`, `app/controllers`, `app/views`,
+  plus `app/helpers`, `app/jobs`, `app/mailers`, and (modern) `app/javascript`.
+- Routing in `config/routes.rb`; the database layer in `db/migrate/*` migrations
+  and `db/schema.rb` (or `db/structure.sql`).
+- Configuration under `config/` (`environments/{development,test,production}.rb`),
+  and encrypted secrets in `config/credentials.yml.enc` + `config/master.key`.
+- Test framework from what's present: **RSpec** (`spec/`, `.rspec`,
+  `rspec-rails` in the Gemfile) **or** Minitest (`test/`, the Rails default).
+  **Infer from what exists.**
+
+## What to look for in recon
+
+- The **real** test command: `bundle exec rspec` (RSpec) or `bin/rails test`
+  (Minitest), plus system/integration variants (`bin/rails test:system`).
+  Confirm the directory (`spec/` vs `test/`) and any factories
+  (`factory_bot`) vs fixtures.
+- The **real** lint/format gate: `rubocop` (often `bundle exec rubocop`,
+  `.rubocop.yml`), Standard, or `erb_lint`/`brakeman` — capture how it's
+  invoked.
+- The migration workflow (`bin/rails db:migrate`, `db:rollback`,
+  `db:schema:load`) and whether the schema is `schema.rb` or `structure.sql`.
+- Background jobs (Active Job adapter: Sidekiq/Resque/GoodJob), and the
+  front-end approach (Hotwire/Turbo + Stimulus, importmaps/jsbundling,
+  ViewComponent).
+- Where secrets/config live: `config/credentials*`, `Rails.application.config`,
+  `ENV`, and the multi-environment layout.
+
+## Stack-specific skills/agents/commands to generate
+
+- Skills: `model-add` (model + migration + spec), `migration` (write/apply a
+  migration safely), `controller` (controller + routes + request spec),
+  `endpoint`/`resource` (resourceful route + controller + view/JSON),
+  optionally `job` (Active Job) and `mailer` if present.
+- Agents: baseline roles + a `migration-author` / `db-reviewer` persona aware of
+  reversible migrations and zero-downtime concerns.
+- Commands: the five DWP commands + `code-review`, `pr`, `commit`.
+
+## Doc emphases
+
+- `ARCHITECTURE.md` — request → route → controller → model → view/serializer
+  flow, Active Record associations, jobs/mailers, Hotwire/Turbo if present.
+- `TESTING_GUIDE.md` — RSpec vs Minitest, model/request/system specs, factories
+  vs fixtures, how to run a single spec/test file.
+- `SECURITY.md` — `config/credentials` + `master.key` handling, strong
+  parameters, CSRF, auth (Devise/has_secure_password), Brakeman.
+- Per-module docs: per domain area (its models, controllers, jobs, mailers).
+
+## Typical validation command (FIND the real one)
+
+Often `bundle exec rubocop && bundle exec rspec`, or `bin/rails test` for a
+Minitest app. **Do not assume** the test framework or lint setup — read the
+`Gemfile`, `.rubocop.yml`, `bin/`, and CI, and capture the exact command.

--- a/skills/deepworkplan/onboard/presets/react-native.md
+++ b/skills/deepworkplan/onboard/presets/react-native.md
@@ -1,0 +1,67 @@
+# Preset — React Native / Expo (TypeScript)
+
+> Reasoning aid, not a template. Verify against the live repo; detected reality
+> wins. Capture the **real** validation command, not the example below.
+
+## Signals that identify this stack
+
+- `react-native` in `package.json` `dependencies`, with `react` alongside it.
+- **Expo managed**: `expo` in deps, an `app.json` or `app.config.ts`/`app.config.js`,
+  an `expo` key, and often no committed `ios/`/`android/` folders.
+- **Bare React Native**: committed `ios/` (with a `*.xcodeproj`/`Podfile`) and
+  `android/` (with `build.gradle`) folders, a `react-native.config.js`. **Detect
+  managed vs bare early — it changes nearly every command.**
+- `metro.config.js`/`metro.config.cjs` (the bundler), `babel.config.js` with
+  `babel-preset-expo` or `metro-react-native-babel-preset`.
+- Navigation: React Navigation (`@react-navigation/*`) or **expo-router** (an
+  `app/` directory with file-based routes, `expo-router` in deps).
+- Package manager from the lockfile: `pnpm-lock.yaml` → pnpm, `yarn.lock` →
+  yarn, `package-lock.json` → npm; Expo projects often pin via `expo install`.
+  **Infer from the lockfile present.**
+- Layout: `src/`/`app/` with `screens/`/`components/`, `navigation/`, `hooks/`,
+  `services/`; `assets/` for fonts/images.
+
+## What to look for in recon
+
+- The **real** test setup: Jest (`jest.config.*` or a `jest` key,
+  `jest-expo`/`react-native` preset) with `@testing-library/react-native`. Test
+  files `*.test.tsx`/`*.test.ts` or under `__tests__/`. **Confirm the preset.**
+- The **real** lint/type-check: `eslint` (`.eslintrc`/`eslint.config.js`,
+  often `eslint-config-expo` or `@react-native`), `tsc --noEmit`/a `type-check`
+  script, Prettier. Capture verbatim.
+- The **real** run/build path, which depends on managed vs bare:
+  - Expo managed: `expo start`, `expo prebuild`, and **EAS** (`eas build`,
+    `eas.json`) for store builds.
+  - Bare RN: `npx react-native run-ios`/`run-android`, `pod install`,
+    `xcodebuild`/Gradle for release builds.
+- Native modules / config plugins (Expo `plugins`), and where secrets/env live
+  (`.env`, `app.config.ts` `extra`, EAS secrets).
+
+## Stack-specific skills/agents/commands to generate
+
+- Skills: `screen` (screen + navigation entry + test), `component` (RN component +
+  test), `hook` (custom hook), `navigator`/`route` (React Navigation stack or an
+  expo-router file), `native-module` only if bare RN with custom native code.
+- Agents: baseline + a `mobile-author` / `frontend-reviewer` persona aware of
+  the managed-vs-bare split, platform branches (iOS/Android), and list/perf
+  pitfalls (FlatList, memoization).
+- Commands: the five DWP commands + `code-review`, `pr`, `commit`.
+
+## Doc emphases
+
+- `ARCHITECTURE.md` — screen/navigation structure (React Navigation vs
+  expo-router), state, the native config (managed vs bare), EAS pipeline.
+- `STANDARDS.md` — component/screen conventions, styling approach
+  (`StyleSheet`/styled), platform-specific files (`*.ios.tsx`/`*.android.tsx`).
+- `TESTING_GUIDE.md` — Jest + `@testing-library/react-native`, the preset,
+  the real `*.test.tsx` pattern, mocking native modules.
+- Per-module docs: per feature folder (its screens, navigators, hooks, services).
+
+## Typical validation command (FIND the real one)
+
+Commonly `npm run lint && npm run type-check && npm test` (or the
+pnpm/yarn equivalent). The **build/run** command is managed-vs-bare specific
+(`expo start`/`eas build` vs `npx react-native run-ios`/Gradle). **Do not
+assume** the package manager, the preset, or whether it's managed or bare —
+read `package.json`, `app.json`/`app.config.*`, check for `ios/`/`android/`,
+and capture the exact commands.

--- a/skills/deepworkplan/onboard/presets/rust.md
+++ b/skills/deepworkplan/onboard/presets/rust.md
@@ -1,0 +1,57 @@
+# Preset — Rust (Cargo)
+
+> Reasoning aid, not a template. Verify every assumption against the live repo;
+> detected reality wins. Capture the **real** validation command, not the
+> example below.
+
+## Signals that identify this stack
+
+- `Cargo.toml` and `Cargo.lock` at the repo (or crate) root; `Cargo.toml`
+  declares `[package]`, `[dependencies]`, and often `[features]`.
+- Entry point: `src/main.rs` (binary crate) or `src/lib.rs` (library crate);
+  some crates ship both, plus extra binaries under `src/bin/`.
+- Module tree under `src/` via `mod`/`pub mod` and `mod.rs` or `foo.rs`+`foo/`.
+- **Workspace** monorepos: a root `Cargo.toml` with `[workspace]` and
+  `members = [...]`, each member its own crate with its own `Cargo.toml`.
+- Edition (`edition = "2021"/"2024"`) and an MSRV (`rust-version`) may be pinned;
+  a `rust-toolchain.toml` may pin the toolchain. `build.rs` indicates a build
+  script. **Read what's present** rather than assuming.
+
+## What to look for in recon
+
+- The **real** test command: `cargo test` (workspace-wide vs `-p <crate>`),
+  whether `cargo nextest run` is used, and where tests live — inline
+  `#[cfg(test)] mod tests` vs integration tests under `tests/` vs doctests.
+- The **real** lint/format gate: `cargo clippy` (often `-- -D warnings` to fail
+  on lints) and `cargo fmt --check` (or `cargo fmt -- --check`). Confirm whether
+  CI denies warnings.
+- The **real** build: `cargo build` vs `cargo build --release`; which features
+  are enabled (`--all-features`, `--no-default-features`, specific `--features`).
+- Feature flags and their meaning; `unsafe` blocks and FFI boundaries; any
+  `build.rs` codegen. Async runtime if present (`tokio`/`async-std`).
+
+## Stack-specific skills/agents/commands to generate
+
+- Skills: `module-add` (new module + tests), `error-type` (define an error enum /
+  `thiserror` variant), `crate-add` (new workspace member wired into `members`),
+  optionally `bench` (criterion) and `feature-flag` (gate code behind a feature).
+- Agents: baseline roles + an `ownership-reviewer` / `unsafe-auditor` persona
+  aware of borrow/lifetime and `unsafe` safety invariants.
+- Commands: the five DWP commands + `code-review`, `pr`, `commit`.
+
+## Doc emphases
+
+- `ARCHITECTURE.md` — crate/workspace boundaries, module tree, trait/ownership
+  model, error-handling strategy (`Result`/`?`), async runtime if any.
+- `TESTING_GUIDE.md` — unit (`#[cfg(test)]`) vs integration (`tests/`) vs
+  doctests, how to scope a single crate (`-p`), fixtures/builders.
+- `SECURITY.md` — `unsafe`/FFI boundaries and their invariants, dependency
+  audit (`cargo audit`/`cargo deny`), secrets handling.
+- Per-module docs: one per significant crate (workspace) or module group.
+
+## Typical validation command (FIND the real one)
+
+Often `cargo fmt --check && cargo clippy --all-targets -- -D warnings && cargo
+test` (workspace-wide), with a separate `cargo build --release` for release
+artifacts. **Do not assume** the feature set or whether warnings are denied —
+read the `Makefile`/`justfile`/CI and capture the exact command.

--- a/skills/deepworkplan/onboard/presets/spring-boot.md
+++ b/skills/deepworkplan/onboard/presets/spring-boot.md
@@ -1,0 +1,66 @@
+# Preset — Spring Boot (Java / Kotlin)
+
+> Reasoning aid, not a template. Verify every assumption against the live repo;
+> detected reality wins. Capture the **real** validation command, not the
+> example below.
+
+## Signals that identify this stack
+
+- Build manifest: `pom.xml` (Maven) **or** `build.gradle`/`build.gradle.kts`
+  (Gradle), declaring `spring-boot-starter-parent` / the Spring Boot plugin and
+  `spring-boot-starter-*` dependencies. **Infer the build tool from which file
+  is present.**
+- A wrapper: `./mvnw` (`.mvn/wrapper/`) or `./gradlew` (`gradle/wrapper/`) — use
+  it, not a global Maven/Gradle.
+- Source layout `src/main/java` (or `src/main/kotlin`) + `src/test/java`, and a
+  `@SpringBootApplication`-annotated entrypoint with `SpringApplication.run(...)`.
+- The layered stereotype model: `@RestController`/`@Controller`, `@Service`,
+  `@Repository` (often Spring Data `JpaRepository`), `@Configuration`,
+  `@Component`, with constructor injection.
+- Config in `src/main/resources/application.yml` / `application.properties`,
+  often with profile variants (`application-<profile>.yml`).
+
+## What to look for in recon
+
+- The **real** test command: `./mvnw test` (Maven Surefire/Failsafe) or
+  `./gradlew test`, running JUnit 5 with Spring Boot Test
+  (`@SpringBootTest`, `@WebMvcTest`, `@DataJpaTest`, `MockMvc`, Testcontainers).
+  Capture the exact wrapper invocation.
+- The **real** lint/format gate: Checkstyle, Spotless, PMD, SpotBugs, or
+  ktlint/detekt (Kotlin) — and how it's invoked (`./mvnw verify`,
+  `./gradlew check`, `spotlessApply`).
+- Build tool specifics: Maven phases/profiles vs Gradle tasks; the full build
+  command (`./mvnw verify` vs `./gradlew build`).
+- Persistence layer: Spring Data JPA/JDBC, Hibernate, and the migration tool
+  (Flyway `db/migration/V*.sql` or Liquibase changelogs).
+- Configuration and secrets: active profiles (`SPRING_PROFILES_ACTIVE`),
+  externalized config, and where secrets resolve from (env vars, Vault, config
+  server).
+
+## Stack-specific skills/agents/commands to generate
+
+- Skills: `controller-add` (`@RestController` + request mapping + test),
+  `service` (`@Service` business-logic bean + test), `repository` (Spring Data
+  repository + entity), `entity` (`@Entity` + migration), optionally `migration`
+  (Flyway/Liquibase) and `config-properties` (`@ConfigurationProperties`).
+- Agents: baseline roles + an `api-reviewer` / `persistence-author` persona
+  aware of transaction boundaries, layering, and migration safety.
+- Commands: the five DWP commands + `code-review`, `pr`, `commit`.
+
+## Doc emphases
+
+- `ARCHITECTURE.md` — layering (controller → service → repository → entity),
+  Spring context/bean wiring, transaction boundaries, REST surface.
+- `TESTING_GUIDE.md` — JUnit 5 + Spring Boot Test slices (`@WebMvcTest` /
+  `@DataJpaTest`), `MockMvc`, Testcontainers, how to scope a single test class
+  with `-Dtest=` (Maven) or `--tests` (Gradle).
+- `SECURITY.md` — Spring Security config, auth (JWT/OAuth2/sessions),
+  externalized secrets, profile-based config.
+- Per-module docs: one per domain/feature package (its controllers, services,
+  repositories, entities).
+
+## Typical validation command (FIND the real one)
+
+Often `./mvnw verify` (Maven) or `./gradlew check` (Gradle) — which run tests
+plus the lint/format/static-analysis gates. **Do not assume** the build tool or
+goals — read `pom.xml`/`build.gradle`/CI and capture the exact wrapper command.

--- a/skills/deepworkplan/onboard/presets/sveltekit.md
+++ b/skills/deepworkplan/onboard/presets/sveltekit.md
@@ -1,0 +1,66 @@
+# Preset — SvelteKit
+
+> Reasoning aid, not a template. Verify against the live repo; detected reality
+> wins. Capture the **real** validation command, not the example below.
+
+## Signals that identify this stack
+
+- `@sveltejs/kit` and `svelte` in `package.json`, a `svelte.config.js`, and a
+  `vite.config.js`/`vite.config.ts` (SvelteKit is Vite-based).
+- File-based routing under `src/routes/`: `+page.svelte` (UI), `+page.ts`
+  (universal `load`), `+page.server.ts` (server `load` + form `actions`),
+  `+layout.svelte`/`+layout.ts`, and `+server.ts` (standalone API endpoints with
+  `GET`/`POST`/… handlers).
+- `src/lib/` (the `$lib` alias), `src/app.html`, `src/hooks.server.ts` /
+  `src/hooks.client.ts`, and `src/app.d.ts` (the `App` namespace types).
+- The configured **adapter** in `svelte.config.js`: `adapter-auto`,
+  `adapter-node`, `adapter-static`, `adapter-cloudflare`, `adapter-vercel` —
+  it decides SSR vs prerender and the deploy target.
+- Package manager from the lockfile: `pnpm-lock.yaml` → pnpm, `yarn.lock` →
+  yarn, `package-lock.json` → npm. **Infer from the lockfile present.**
+
+## What to look for in recon
+
+- The **real** `package.json` scripts: `dev`, `build` (`vite build`),
+  `preview`, `check` (`svelte-kit sync && svelte-check`), `lint` (`eslint` +
+  often `prettier --check`), and the test command. Capture them verbatim.
+- Type-checking is `svelte-check` (not bare `tsc`) — it understands `.svelte`
+  files; the script is usually `check` / `check:watch`.
+- Test convention: unit/component via **Vitest** (`vitest.config` /
+  `vite.config` test block) with `@testing-library/svelte`; end-to-end via
+  **Playwright** (`playwright.config.ts`, `tests/`). Note `*.test.ts` /
+  `*.spec.ts` naming.
+- The `load`/`actions` model: which routes use server vs universal loads, form
+  actions, and `+server.ts` endpoints; where env/secrets live (`$env/static/*`,
+  `$env/dynamic/*`, `.env`).
+- Svelte version (4 vs 5 runes) — it changes component/reactivity conventions.
+
+## Stack-specific skills/agents/commands to generate
+
+- Skills: `route` (`+page.svelte` + `load` + optional `+page.server.ts`
+  actions), `endpoint` (`+server.ts` with typed request handlers + test),
+  `component` (`$lib` component + test), `load-function` (server/universal load
+  + invalidation), optionally `form-action`.
+- Agents: baseline + a `frontend-reviewer` persona aware of the server-vs-
+  universal `load` boundary, progressive enhancement, and the adapter's SSR/
+  prerender constraints.
+- Commands: the five DWP commands + `code-review`, `pr`, `commit`.
+
+## Doc emphases
+
+- `ARCHITECTURE.md` — routing tree, `load` model (server vs universal), form
+  actions, `+server.ts` endpoints, hooks, the adapter and SSR/prerender story.
+- `STANDARDS.md` — component conventions, `$lib` boundaries, Svelte 4 vs 5
+  (runes) idioms, props/typing.
+- `TESTING_GUIDE.md` — Vitest + `@testing-library/svelte` patterns, Playwright
+  e2e flow, the real `*.test.ts`/`*.spec.ts` pattern, plus `svelte-check` as a
+  gate.
+- `PERFORMANCE.md` — prerender vs SSR per route, the adapter target, asset/
+  bundle budgets.
+
+## Typical validation command (FIND the real one)
+
+Commonly `pnpm run lint && pnpm run check && pnpm test && pnpm run build`
+(or npm/yarn), where `check` is `svelte-check` and `build` is `vite build`.
+**Do not assume the package manager or script names** — read `package.json`,
+`svelte.config.js`, and CI, and capture the exact commands.

--- a/skills/deepworkplan/onboard/presets/swift-ios.md
+++ b/skills/deepworkplan/onboard/presets/swift-ios.md
@@ -1,0 +1,73 @@
+# Preset — Swift / iOS
+
+> Reasoning aid, not a template. Verify against the live repo; detected reality
+> wins. Capture the **real** validation command, not the example below.
+
+## Signals that identify this stack
+
+- An `*.xcodeproj` and/or `*.xcworkspace` at the repo root (a workspace usually
+  means CocoaPods or multiple projects), and `*.swift` source files.
+- **Dependency manager** — detect which:
+  - `Package.swift` → **SwiftPM** (and `Sources/`, `Tests/` per the SPM layout).
+  - `Podfile` + `Podfile.lock` → **CocoaPods** (open the `.xcworkspace`, run
+    `pod install`).
+  - `Cartfile` → **Carthage** (rarer).
+  **Infer from the files present.**
+- `*.xcodeproj/project.pbxproj` (targets, schemes), `Info.plist`, `*.entitlements`,
+  and an `xcschemes` set under `*.xcodeproj/xcshareddata/`.
+- **UI layer** — detect which:
+  - SwiftUI: types conforming to `View`, a `body: some View`, `@State`/
+    `@StateObject`/`@Observable`, an `App` struct with `@main`.
+  - UIKit: `UIViewController`/`UIView` subclasses, `*.storyboard`/`*.xib`,
+    `AppDelegate`/`SceneDelegate`.
+  **Confirm SwiftUI vs UIKit — it changes nearly every screen-level skill.**
+- Layout: `Sources/`/an app target folder with feature groups, `Models/`,
+  `Views/`, `ViewModels/` (MVVM is common), `Resources/`, `Tests/`/`*Tests/`.
+
+## What to look for in recon
+
+- The **real** test command: `xcodebuild test -scheme <Scheme> -destination
+  'platform=iOS Simulator,name=...'` (app projects) vs `swift test` (an SPM
+  library). Tests use **XCTest** (`XCTestCase`, `func test...`) and possibly
+  the newer **Swift Testing** (`import Testing`, `@Test`). **Confirm which.**
+- The **real** lint/format gate: **SwiftLint** (`.swiftlint.yml`, `swiftlint`)
+  and/or **swift-format** (`.swift-format`, `swift format lint`). Capture
+  verbatim, and note if it runs as an Xcode build phase.
+- The **real** build: `xcodebuild -scheme <Scheme> build` / `swift build`, the
+  scheme and destination, and any `fastlane` lanes (`fastlane/Fastfile`) wrapping
+  build/test/release.
+- The dependency manager — it changes setup (`pod install` /
+  `swift package resolve`) and whether you open the project or the workspace.
+- Where signing/secrets live (provisioning profiles, `*.entitlements`, fastlane
+  match, CI secrets) — flag, don't touch.
+
+## Stack-specific skills/agents/commands to generate
+
+- Skills: a UI-shaped skill matching the layer — `swiftui-view` (View +
+  preview + test) or `uikit-screen` (view controller + test); `viewmodel`
+  (if MVVM), `model` (Codable type + test), `service`/`networking-client`.
+- Agents: baseline + a `swift-author` / `ios-reviewer` persona aware of the
+  SwiftUI-vs-UIKit split, value-vs-reference types, optional handling, and
+  concurrency (`async`/`await`, actors, `@MainActor`).
+- Commands: the five DWP commands + `code-review`, `pr`, `commit`.
+
+## Doc emphases
+
+- `ARCHITECTURE.md` — SwiftUI vs UIKit, the app/scene lifecycle, the
+  architecture pattern (MVVM/TCA/MVC), navigation, the networking/data layer,
+  the dependency manager.
+- `STANDARDS.md` — Swift conventions (value types, optionals, access control,
+  `async`/`await`), file/feature layout, the SwiftLint/swift-format ruleset.
+- `TESTING_GUIDE.md` — XCTest (or Swift Testing), the scheme/destination to run,
+  the real `*Tests.swift` pattern, mocking via protocols, UI tests if present.
+- Per-module docs: per feature group (its views/view controllers, view models,
+  models, services).
+
+## Typical validation command (FIND the real one)
+
+For an app project, commonly `swiftlint && xcodebuild test -scheme <Scheme>
+-destination 'platform=iOS Simulator,name=iPhone 15'` (often wrapped in a
+fastlane lane or a `Makefile`); for an SPM library, `swift build && swift
+test`. **Do not assume** the dependency manager, the UI layer, the scheme, or
+whether fastlane wraps it — read `Package.swift`/`Podfile`, the `*.xcodeproj`
+schemes, any `Fastfile`, and CI, and capture the exact commands.

--- a/skills/deepworkplan/onboard/presets/terraform.md
+++ b/skills/deepworkplan/onboard/presets/terraform.md
@@ -1,0 +1,64 @@
+# Preset — Terraform / IaC (Terraform / OpenTofu)
+
+> Reasoning aid, not a template. Verify every assumption against the live repo;
+> detected reality wins. Capture the **real** validation command, not the
+> example below.
+
+## Signals that identify this stack
+
+- `*.tf` files (HCL) — conventionally split into `main.tf`, `variables.tf`,
+  `outputs.tf`, and `providers.tf`/`versions.tf` — plus a committed
+  `.terraform.lock.hcl` (provider lock).
+- Reusable code under `modules/`, each module exposing `variables.tf` and
+  `outputs.tf`; root configs that call modules with `module "x" { source = ... }`.
+- A `terraform { backend "..." }` block declaring **remote state** (S3 +
+  DynamoDB lock, GCS, azurerm, Terraform Cloud / HCP, or a Tofu equivalent), and
+  one or more `provider` blocks with version constraints.
+- Variable inputs via `*.tfvars` / `*.auto.tfvars`; the `.terraform/` directory
+  is local cache and is git-ignored. **Infer the real backend from the code.**
+- **OpenTofu** variant: the same `.tf`/HCL files but driven by the `tofu` CLI
+  (often a `.terraform-version`/`.tool-versions` or CI hints at which binary).
+
+## What to look for in recon
+
+- The **real** validation gate: `terraform fmt -check -recursive`,
+  `terraform validate`, `tflint` (read `.tflint.hcl`), and `terraform plan`
+  (read-only). Security/policy scanners may be present: `tfsec`, `checkov`,
+  `terraform-compliance`. Substitute `tofu` for `terraform` if OpenTofu is used.
+- **Never** treat `terraform apply` as a validation gate — it mutates real
+  infrastructure. `plan` is the safe, read-only check.
+- How **environments** are separated: workspaces (`terraform workspace`), or
+  per-environment directories (`envs/dev`, `envs/staging`, `envs/prod`), or
+  layered `*.tfvars`. Identify which pattern this repo uses.
+- Backend/state location and locking, provider/version pinning, and where
+  **secrets** live (never in state-readable plaintext — vars, a secrets manager,
+  Vault, env). `terraform init` is required before validate/plan.
+
+## Stack-specific skills/agents/commands to generate
+
+- Skills: `module-add` (new reusable module with `variables.tf`/`outputs.tf`),
+  `resource-add` (resource + variables + outputs wired in), `env-add` (new
+  environment dir/workspace + tfvars), optionally `provider-pin` and a
+  `plan-review` helper that summarizes a `plan` diff.
+- Agents: baseline roles + a `iac-reviewer` / `state-safety` persona aware of
+  state mutation, drift, blast radius, and least-privilege provider creds.
+- Commands: the five DWP commands + `code-review`, `pr`, `commit`.
+
+## Doc emphases
+
+- `ARCHITECTURE.md` — module composition, root configs vs modules, the
+  provider/backend topology, environment separation strategy.
+- `SECURITY.md` — state secrecy (remote state can contain secrets), least-
+  privilege provider credentials, secrets handling, policy scanning
+  (`tfsec`/`checkov`), and who can `apply`.
+- `OPERATIONS.md`/runbook — the init → fmt → validate → plan → (gated) apply
+  flow, state locking, and rollback/import procedures.
+- Per-module docs: one per reusable module (its inputs, outputs, side effects).
+
+## Typical validation command (FIND the real one)
+
+Often `terraform init -backend=false && terraform fmt -check -recursive &&
+terraform validate && tflint`, with `terraform plan` as the change preview
+(substitute `tofu` for OpenTofu). **Do not assume** the backend, environment
+layout, or scanner set — read the `Makefile`/`.tflint.hcl`/CI and capture the
+exact command.

--- a/skills/deepworkplan/onboard/presets/ts-lambda.md
+++ b/skills/deepworkplan/onboard/presets/ts-lambda.md
@@ -1,0 +1,63 @@
+# Preset — TS Lambda (Serverless) (Serverless Framework / SAM / CDK)
+
+> Reasoning aid, not a template. Verify every assumption against the live repo;
+> detected reality wins. Capture the **real** validation command, not the
+> example below.
+
+## Signals that identify this stack
+
+- A deploy descriptor — exactly which one shapes the whole flow:
+  - `serverless.yml` → **Serverless Framework** (`functions:` map, `provider:`,
+    plugins like `serverless-esbuild`).
+  - `template.yaml`/`template.yml` with `Transform: AWS::Serverless-2016-10-31`
+    → **AWS SAM**.
+  - `cdk.json` + a `bin/`/`lib/` stack tree → **AWS CDK** (functions defined in
+    TypeScript constructs).
+- `tsconfig.json` plus `aws-lambda` types; handler files exporting `handler`
+  (e.g. `export const handler = async (event) => ...`).
+- Per-function layout under `src/functions/` or `src/handlers/`, often one
+  directory per function. Bundler config: `esbuild`/`esbuild.config`, or `tsc`.
+- Package manager from the lockfile (pnpm/yarn/npm). **Infer the toolchain
+  (Serverless vs SAM vs CDK) from the descriptor that's present** — do not assume.
+
+## What to look for in recon
+
+- The **real** scripts: lint (`eslint`), type-check (`tsc --noEmit` /
+  `type:check`), test (`jest`/`vitest`), and the bundle step (esbuild vs tsc).
+  Test convention is usually `*.test.ts`/`*.spec.ts` colocated or under `tests/`.
+- The **real** package/synth command — the safe, read-only gate:
+  `sls package` (Serverless), `sam build` (+ `sam validate`), or `cdk synth`.
+  **`sls deploy` / `sam deploy` / `cdk deploy` mutate the AWS account — never run
+  them as a validation gate.**
+- Event sources per function (API Gateway/HTTP, SQS, SNS, EventBridge, S3,
+  DynamoDB streams) — this shapes the handler skill and the event types.
+- **IAM scope per function** (least privilege), cold-start/bundle-size budget,
+  and where secrets/config live (SSM Parameter Store, Secrets Manager, env vars).
+
+## Stack-specific skills/agents/commands to generate
+
+- Skills: `lambda-fn` (new handler + typed event + unit test + descriptor
+  wiring), `event-source` (wire a trigger to a function), `iam-policy` (scope a
+  least-privilege role), optionally `layer` (shared Lambda layer) and
+  `local-invoke` (run a function locally via `sls invoke local`/`sam local`).
+- Agents: baseline roles + a `security-reviewer` / `iam-auditor` persona focused
+  on least-privilege IAM, and an `api-reviewer` for contract/error handling.
+- Commands: the five DWP commands + `code-review`, `pr`, `commit`.
+
+## Doc emphases
+
+- `ARCHITECTURE.md` — event lifecycle per function, the toolchain (Serverless /
+  SAM / CDK), function topology and their triggers, shared layers/utilities.
+- `SECURITY.md` — **least-privilege IAM per function** (call this out
+  explicitly), secrets handling (SSM/Secrets Manager, never hard-coded),
+  input validation at the event boundary, the sensitive-data boundary.
+- `PERFORMANCE.md` — cold starts, bundle size (tree-shaking via esbuild),
+  memory/timeout tuning, provisioned concurrency, connection reuse.
+- Per-module docs: one per function (its event source, IAM role, dependencies).
+
+## Typical validation command (FIND the real one)
+
+Often `npm run lint && tsc --noEmit && npm test && sls package` (or
+`sam build && sam validate`, or `cdk synth`). **Do not assume** the toolchain,
+package manager, or script names — read `package.json`/the descriptor/CI and
+capture the exact commands, treating synth/package (not deploy) as the gate.


### PR DESCRIPTION
## Summary

Broadens the onboarding **preset catalog** and completes **agent-host coverage** so the skill matches the support matrix now published on deepworkplan.com.

### New presets (6 → 22)
16 new per-stack reasoning guides under `skills/deepworkplan/onboard/presets/`, each following the existing `django.md` structure (signals → recon → skills/agents/commands to generate → doc emphases → validation command):

- **Backend/API:** FastAPI, NestJS, Spring Boot, Rails, Laravel
- **Frontend:** Next.js, SvelteKit, Nuxt, Angular
- **Mobile:** React Native (Expo), Flutter, Swift/iOS
- **Systems/Infra:** Rust, Go, Terraform/IaC, TypeScript Lambda (Serverless)

These join the existing Django, Vue/Vite, Astro/Svelte, Node/TS service, Python package/CLI, and `generic` fallback. `presets/README.md` index and `onboard/SKILL.md` references updated to the broader catalog. Presets remain **reasoning aids, not templates** — detected reality wins.

### New install hosts: OpenCode + Antigravity
`setup.sh` already supported claude, cursor, codex, windsurf, copilot, cline, gemini. This adds the two remaining agents we now document as fully supported:

| Host | Skills dir |
|------|-----------|
| `opencode` | `~/.config/opencode/skills` |
| `antigravity` | `~/.antigravity/skills` |

Wired into `--host`, `resolve_skills_dir`, and auto-detect, plus the README.md and docs/INSTALLATION.md path tables.

## Validation
- `bash -n setup.sh` — syntax OK
- Smoke-tested both new hosts against a throwaway `HOME`: `--host opencode` and `--host antigravity` create the expected `deepworkplan*` symlinks; unknown hosts still rejected (`Unknown agent: nonsense`).
- No `version:`/`CHANGELOG.md` hand-edits (auto-release bot owns them); this is a `feat` → MINOR bump on merge.

## ⚠️ Maintainer check
The `opencode` (`~/.config/opencode/skills`) and `antigravity` (`~/.antigravity/skills`) install paths follow the existing per-agent convention but should be **confirmed against each agent's actual skills directory** before release — same caveat that applies to the other non-Claude host paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)