### PR TITLE
feat(spec): require PRODUCT_SPEC.md in the docs/ standard (MUST, all archetypes)

### DIFF
--- a/skills/deepworkplan/onboard/SKILL.md
+++ b/skills/deepworkplan/onboard/SKILL.md
@@ -248,11 +248,14 @@ Each doc must contain **real** content:
 
 - `PRODUCT_SPEC.md` — the non-technical product/why doc: the problem the repo
   solves, who it is for, its key capabilities/features, success criteria, and
-  explicit non-goals. Reason it from the README, package description, public
-  API, and any roadmap/issues — never a generic stub. **Required for every repo,
-  including libraries, CLIs, and internal tools**: if there are no end users,
-  frame the product as its consumers (who calls this API, and why they choose
-  it). This is the *why*; the docs below are the *how*.
+  explicit non-goals. It **MUST read plainly enough that anyone — a person or an
+  agent, technical or not — can understand what this repository is and why it
+  exists at a glance**; that is the whole point of the document. Reason it from
+  the README, package description, public API, and any roadmap/issues — never a
+  generic stub. **Required for every repo, including libraries, CLIs, and
+  internal tools**: if there are no end users, frame the product as its
+  consumers (who calls this API, and why they choose it). This is the *why*; the
+  docs below are the *how*.
 - `ARCHITECTURE.md` — the real components, data flow, and deployment shape from
   recon; an annotated diagram of the actual module layout.
 - `STANDARDS.md` — the repo's real coding conventions, naming, import order,

--- a/skills/deepworkplan/onboard/SKILL.md
+++ b/skills/deepworkplan/onboard/SKILL.md
@@ -70,8 +70,9 @@ When this flow finishes, the target repo contains:
    repo's **real, runnable** commands; plus `CLAUDE.md → AGENTS.md`.
 2. **`docs/`** — the standard categories, each filled with **real**
    repo-specific content (real commands, real module names, real test pattern):
-   `ARCHITECTURE.md`, `STANDARDS.md`, `TESTING_GUIDE.md`,
-   `DEVELOPMENT_COMMANDS.md`, `SECURITY.md`, `PERFORMANCE.md`,
+   `PRODUCT_SPEC.md` (the non-technical product/why doc — **required for every
+   repo, libraries included**), `ARCHITECTURE.md`, `STANDARDS.md`,
+   `TESTING_GUIDE.md`, `DEVELOPMENT_COMMANDS.md`, `SECURITY.md`, `PERFORMANCE.md`,
    `AI_AGENT_ONBOARDING.md`, `AI_AGENT_COLLAB.md`, optional
    `PR_REVIEW_WORKFLOW.md` / `ECOSYSTEM_CONTEXT.md`, and a `docs/README.md`
    index.
@@ -237,7 +238,7 @@ Never duplicate `AGENTS.md` content into `CLAUDE.md`.
 
 Produce the standard categories, **each adapted** from recon — an empty or
 generic doc is a failure. The conformance floor (all **MUST**):
-`ARCHITECTURE.md`, `STANDARDS.md`, `TESTING_GUIDE.md`,
+`PRODUCT_SPEC.md`, `ARCHITECTURE.md`, `STANDARDS.md`, `TESTING_GUIDE.md`,
 `DEVELOPMENT_COMMANDS.md`, `SECURITY.md`, `AI_AGENT_ONBOARDING.md`,
 `AI_AGENT_COLLAB.md`. **SHOULD**: `PERFORMANCE.md`, plus optional
 `PR_REVIEW_WORKFLOW.md` and `ECOSYSTEM_CONTEXT.md`. Always add a
@@ -245,6 +246,13 @@ generic doc is a failure. The conformance floor (all **MUST**):
 
 Each doc must contain **real** content:
 
+- `PRODUCT_SPEC.md` — the non-technical product/why doc: the problem the repo
+  solves, who it is for, its key capabilities/features, success criteria, and
+  explicit non-goals. Reason it from the README, package description, public
+  API, and any roadmap/issues — never a generic stub. **Required for every repo,
+  including libraries, CLIs, and internal tools**: if there are no end users,
+  frame the product as its consumers (who calls this API, and why they choose
+  it). This is the *why*; the docs below are the *how*.
 - `ARCHITECTURE.md` — the real components, data flow, and deployment shape from
   recon; an annotated diagram of the actual module layout.
 - `STANDARDS.md` — the repo's real coding conventions, naming, import order,
@@ -437,7 +445,8 @@ After generating, run this checklist in the target repo. On any failure,
 2. **`CLAUDE.md` resolves to `AGENTS.md`** — the symlink points at `AGENTS.md`,
    or `CLAUDE.md` contains exactly `@AGENTS.md`.
 3. **`docs/` has the standard categories**, each non-empty and repo-specific
-   (the seven MUST files at minimum, plus `docs/README.md`). Grep for leftover
+   (the eight MUST files at minimum — `PRODUCT_SPEC` included — plus
+   `docs/README.md`). Grep for leftover
    placeholder markers (`<...>`, "TODO", "your command here") and fix any.
 4. **Every major source module has a `README.md`** (and complex modules have a
    `docs/`).

--- a/skills/deepworkplan/spec/DOCUMENTATION_STANDARD.md
+++ b/skills/deepworkplan/spec/DOCUMENTATION_STANDARD.md
@@ -140,12 +140,14 @@ commands are repo-specific (§7).
 
 A conformant repository **MUST** maintain a root-level `docs/` folder holding
 categorized markdown guides. Guides **SHOULD NOT** carry YAML frontmatter (they are
-evergreen reference, not lifecycle documents). The audit found the following
-**10 categories** common across the 6 repos; this set is the normative `docs/`
+evergreen reference, not lifecycle documents). The audit found 10 categories
+common across the 6 repos; this standard adds an 11th — **`PRODUCT_SPEC.md`**,
+the product/"why" layer — for **11 categories** total as the normative `docs/`
 standard:
 
 | # | Category file | Requirement | Purpose |
 |---|---------------|-------------|---------|
+| 0 | `PRODUCT_SPEC.md` | **MUST** | The product spec: the problem the repo solves, who it is for, its key capabilities/features, success criteria, and explicit non-goals — the **why** and **for whom**, not the **how**. Deliberately **non-technical**, high-value context. **Every repository is a product** — even a library, CLI, or internal tool: its consumers and their use cases are its product, and they deserve a non-technical spec. A library that omits this hides the very thing a new agent (or human) most needs to understand first. |
 | 1 | `ARCHITECTURE.md` | **MUST** | System design, components, data flow, key decisions. |
 | 2 | `STANDARDS.md` | **MUST** | Coding conventions, naming, import order, error/logging patterns, forbidden anti-patterns. |
 | 3 | `TESTING_GUIDE.md` | **MUST** | Test framework, file-naming pattern, how to run/scope tests, coverage expectation. |
@@ -157,8 +159,9 @@ standard:
 | 9 | `PR_REVIEW_WORKFLOW.md` | **SHOULD** | How PRs are opened, reviewed, and merged in this repo. |
 | 10 | `ECOSYSTEM_CONTEXT.md` | **SHOULD** (individual) / **MUST** (orchestrator hub & multi-repo members) | How this repo relates to sibling repos and the wider product. |
 
-- The five **MUST** categories (`ARCHITECTURE`, `STANDARDS`, `TESTING_GUIDE`, `DEVELOPMENT_COMMANDS`, `SECURITY`) plus `AI_AGENT_ONBOARDING` and `AI_AGENT_COLLAB` constitute the conformance floor for an AI-first repo.
-- A repository **MAY** add domain-specific guides beyond these 10 (e.g. `API_REFERENCE.md`, `DATABASE_SCHEMA.md`, `LOGGING_BEST_PRACTICES.md`, `REDIS_CACHING_BEST_PRACTICES.md`) when the stack warrants. Whether a given domain guide is warranted is part of the **repo-specific 10%** (§7). (All four examples observed live in `api-services/docs/`.)
+- The **MUST** categories (`PRODUCT_SPEC`, `ARCHITECTURE`, `STANDARDS`, `TESTING_GUIDE`, `DEVELOPMENT_COMMANDS`, `SECURITY`) plus `AI_AGENT_ONBOARDING` and `AI_AGENT_COLLAB` constitute the conformance floor for an AI-first repo.
+- `PRODUCT_SPEC.md` is **non-technical by design** and **MUST NOT** be skipped on the grounds that "this repo is just a library/tool." If the repo genuinely has no end users, frame the product as its API/consumers: what it offers, to whom, and why they would choose it. Reason the content from the real repo (README, package description, public API, issues/roadmap) — never a generic stub.
+- A repository **MAY** add domain-specific guides beyond these 11 (e.g. `API_REFERENCE.md`, `DATABASE_SCHEMA.md`, `LOGGING_BEST_PRACTICES.md`, `REDIS_CACHING_BEST_PRACTICES.md`) when the stack warrants. Whether a given domain guide is warranted is part of the **repo-specific 10%** (§7). (All four examples observed live in `api-services/docs/`.)
 - A guide that would fall below ~30 lines **SHOULD** be merged into a sibling; a guide above ~700 lines **SHOULD** be split into a subfolder.
 
 > **Divergence from v1.** v1 required only 5 `docs/` files at "Silver"
@@ -168,6 +171,15 @@ standard:
 > **MUST**, and renames `SETUP.md`→`DEVELOPMENT_COMMANDS.md` to match observed
 > practice (`RECONCILIATION.md` §"Specs"). `SETUP`/`TROUBLESHOOTING` content is
 > not lost: it folds into `DEVELOPMENT_COMMANDS.md` and `AI_AGENT_ONBOARDING.md`.
+>
+> **Added: `PRODUCT_SPEC.md` (category 0, MUST).** The audited 10-category set was
+> entirely engineering/process documentation — it captured the *how* but never the
+> *why*. This standard adds `PRODUCT_SPEC.md` as a required, deliberately
+> **non-technical** product/purpose document so an agent (or human) learns what the
+> repo is *for* and *for whom* before diving into its mechanics. It is a **MUST for
+> every archetype, including libraries, CLIs, and internal tools** — every
+> repository is a product; the spec frames its users/consumers and the value it
+> delivers.
 
 ### 3.2. `docs/README.md` Master Index
 
@@ -316,7 +328,9 @@ the classification heuristic and the full onboarding-difference matrix.
 The v1 Bronze/Silver/Gold/Platinum badge ladder is retained as an **informative**
 self-assessment aid, not a normative requirement. A repository is **AI-first
 conformant** when it satisfies every **MUST** in §§2–7. The optional ladder maps,
-roughly: Bronze = §2 only; Silver = §2 + the five MUST `docs/` categories; Gold =
+roughly: Bronze = §2 only; Silver = §2 + the six MUST `docs/` categories
+(`PRODUCT_SPEC`, `ARCHITECTURE`, `STANDARDS`, `TESTING_GUIDE`,
+`DEVELOPMENT_COMMANDS`, `SECURITY`); Gold =
 + remaining MUST categories + `.agents/` + symlinks; Platinum = + per-module docs
 for all complex modules (§4).
 

--- a/skills/deepworkplan/verify/SKILL.md
+++ b/skills/deepworkplan/verify/SKILL.md
@@ -48,7 +48,7 @@ test -f AGENTS.md && grep -qiE 'quick commands|## commands' AGENTS.md && echo "A
 
 # 3. docs/ with the standard categories
 test -d docs && echo "docs/: present" || echo "docs/: FAIL"
-for d in ARCHITECTURE STANDARDS TESTING_GUIDE DEVELOPMENT_COMMANDS SECURITY AI_AGENT_ONBOARDING; do
+for d in PRODUCT_SPEC ARCHITECTURE STANDARDS TESTING_GUIDE DEVELOPMENT_COMMANDS SECURITY AI_AGENT_ONBOARDING; do
   ls docs/ 2>/dev/null | grep -qi "$d" && echo "  docs/$d: ok" || echo "  docs/$d: missing"
 done
 


### PR DESCRIPTION
## Why

The audited `docs/` standard was **entirely engineering/process documentation** — it captured the *how* (architecture, standards, testing, commands, security) but never the ***why***. A new agent (or human) landing in a repo had no required place to learn **what the repo is for and who it's for** before diving into mechanics. That product/purpose context is high-value and was missing from the conformance floor.

## What

Add **`PRODUCT_SPEC.md`** as a required, deliberately **non-technical** product document:
> the problem the repo solves · who it's for · key capabilities/features · success criteria · explicit non-goals — the **why** and **for whom**, not the **how**.

**MUST for every archetype — libraries, CLIs, and internal tools included.** Every repository is a product: if it has no end users, the spec frames its **API/consumers** and the value they get. It must be reasoned from the real repo (README, package description, public API, roadmap/issues), never a generic stub.

## Changes
- **`spec/DOCUMENTATION_STANDARD.md`** — new **category 0 (`PRODUCT_SPEC.md`, MUST)** in the `docs/` table; added to the conformance floor and the Silver ladder; a divergence note explaining the addition; stale counts reconciled (five→six core MUST docs).
- **`onboard/SKILL.md`** — `PRODUCT_SPEC.md` added to the generated-outcome list, the Phase 4 MUST floor, a dedicated per-doc generation bullet (with the library/consumer framing), and the Phase 8 verification count (seven→eight MUST files).
- **`verify/SKILL.md`** — `PRODUCT_SPEC` added to the `docs/` conformance check loop.

## Notes
- Markdown-only; no SKILL.md frontmatter, scripts, or `.dwp/` convention touched. Version/CHANGELOG left to the auto-release bot (`feat` → MINOR).
- This raises the conformance bar: already-onboarded repos will now be flagged by `verify` as missing `PRODUCT_SPEC.md` until they add one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)