### PR TITLE
feat(addon): design-system addon — repo-root DESIGN.md, default-on when detected

### DIFF
--- a/skills/deepworkplan/addons/README.md
+++ b/skills/deepworkplan/addons/README.md
@@ -63,11 +63,13 @@ An addon MAY additionally ship per-stack presets, examples, or migration notes.
 | Devcontainer support | [`addons/devcontainer/`](devcontainer/SKILL.md) | **Authored** — compose-based `.devcontainer/` + `docker/` with AI-CLI persistence, `dailybot-project-network`, `DOCKER_DEV_ENV=vscode`, project-identity precedence, public-OSS variant, 7 reasoning presets. |
 | Dailybot integration | [`addons/dailybot/`](dailybot/SKILL.md) | **Authored** — opt-in install of the Dailybot agent skill / CLI, auth **deferred** to the Dailybot skill's own consent flow, and an **optional, best-effort, never-blocking** progress/milestone report wired into DWP execution (a plan completion → a Dailybot milestone report). The core methodology has **zero** Dailybot dependency. |
 | Dependency upgrade | [`addons/dependency-upgrade/`](dependency-upgrade/SKILL.md) | **Authored** — opt-in, **package-manager-agnostic** dependency upgrades: detect the repo's real manager (npm/pnpm/yarn + ncu, pip/poetry/uv, cargo, go mod, bundler, composer…), classify by semver, upgrade in safe batches, run the repo's **real** validation gate after each batch, revert a failing batch, summarize. Installs a `/lib-upgrade` delegator into the repo's `.agents/commands/` only when accepted. |
+| Design system | [`addons/design-system/`](design-system/SKILL.md) | **Authored** — opt-in, **frontend-scoped** repo-root `DESIGN.md`: reason about the repo's **real** design tokens (CSS vars / Tailwind config / token files / component styles), document the canonical sections (colors & roles, typography, layout, elevation, shapes, components, responsive, do's & don'ts, agent prompt guide), check **WCAG AA** contrast + token integrity, reconcile an existing `DESIGN.md` instead of clobbering it. Offered by `onboard` **only when a UI surface / design system is detected**. |
 
 > This README is the mechanism doc. The first addon, `addons/devcontainer/`, is
 > the methodology's proof that the mechanism works; the second,
 > `addons/dailybot/`, shows an addon can layer optional team visibility while
 > keeping the methodology fully vendor-neutral; the third,
 > `addons/dependency-upgrade/`, shows an addon can encode a recurring maintenance
-> workflow that reasons about each repo's actual stack (a repo is conformant with
-> zero addons).
+> workflow that reasons about each repo's actual stack; the fourth,
+> `addons/design-system/`, shows an addon can capture durable, repo-native UI
+> design context for frontend repos (a repo is conformant with zero addons).

--- a/skills/deepworkplan/addons/design-system/SKILL.md
+++ b/skills/deepworkplan/addons/design-system/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: deepworkplan-addon-design-system
+description: Optional DeepWorkPlan addon that gives a frontend/UI repo a repo-root DESIGN.md — a Markdown design-system file any coding agent reads to generate UI consistent with the repo's OWN design system. Reasons about the repo's ACTUAL design tokens (CSS custom properties, Tailwind config, token files, component styles) rather than copying a brand file; documents colors & roles, typography, spacing/layout, elevation, shapes, components, responsive behavior, do's & don'ts, and an agent prompt guide; checks contrast (WCAG AA) and token integrity. Frontend-scoped and default-on when a UI/design system is detected (applied in trust mode, strongly recommended in guided mode; never offered for backend/CLI/library-only repos); never required for baseline conformance; reconciles an existing DESIGN.md instead of clobbering it. Use when the developer wants agents to produce on-brand, consistent UI for a frontend repo.
+version: "2.5.0"
+documentation_url: https://deepworkplan.com
+user-invocable: true
+allowed-tools: Bash, Read, Grep, Glob, Edit, Write
+metadata: {"openclaw":{"emoji":"🎨","homepage":"https://deepworkplan.com"}}
+---
+
+# DeepWorkPlan — Design-System Addon
+
+Give a **frontend/UI repo** a repo-root **`DESIGN.md`** so any human or AI agent
+generates UI that matches the repo's **own** design system — instead of the
+unstyled, statistically-common defaults an agent falls back to with no guidance.
+This is an **opt-in addon** — it is **never** required for a repo to be AI-first,
+and it is **only** for repos with a real UI surface.
+
+> ## The rule that overrides everything: REASON about the repo's tokens, then write
+>
+> A `DESIGN.md` is only useful if it reflects **this** repo. The first job is to
+> **read the repo's real design source** — its stylesheet, CSS custom properties,
+> Tailwind config, token files, and component styles (see `SPEC.md` §3–§5 and
+> `templates/presets.md`) — then document those values. **Never paste a
+> third-party brand's `DESIGN.md`** (a Stripe/Linear/etc. catalog entry) into the
+> target repo: reference catalogs are inspiration for *structure*, never content.
+
+## Read these first (all relative inside the skill)
+
+- [`SPEC.md`](SPEC.md) — the normative (RFC-2119) contract: frontend-scope gate,
+  canonical sections, reason-don't-copy, reconcile-don't-clobber, accessibility &
+  token integrity, pragmatic-reference posture, validation step.
+- [`templates/DESIGN.md.md`](templates/DESIGN.md.md) — the annotated `DESIGN.md`
+  skeleton (each canonical section + how to fill it from the repo). The *shape* is
+  fixed; the *content* is reasoned per repo.
+- [`templates/presets.md`](templates/presets.md) — per-stack **reasoning presets**
+  (Tailwind, CSS-variables/vanilla, component-library/design-tokens) — where to
+  find tokens in each stack. A *starting checklist*, not an answer key —
+  **detected reality wins**.
+- [`templates/agent_prompt_guide.md`](templates/agent_prompt_guide.md) — the
+  "Agent Prompt Guide" block to embed so downstream agents know how to follow
+  `DESIGN.md`.
+- [`templates/design-system-command.md`](templates/design-system-command.md) — the
+  **optional** `/design-system` delegator this addon MAY install into the target
+  repo's `.agents/commands/` (only when accepted and wanted).
+- `../README.md` — the addon mechanism (opt-in, reconcile-don't-clobber, contract).
+
+## When this runs
+
+- From **`onboard` Phase 7b** — after the core AI-first scaffolding. This addon is
+  **default-on when detected** (`SPEC.md` §3.1): when a frontend/UI surface **is**
+  detected, `onboard` **applies** it in trust mode (and **strongly recommends** it
+  in guided mode); when no UI surface is detected it is **not** offered. Either way
+  the developer may decline and the repo stays baseline-conformant.
+- **Directly** — `/deepworkplan-addon-design-system` on an already-onboarded repo
+  to create or refresh `DESIGN.md`, or via the installed `/design-system`
+  delegator if one was added.
+
+## The flow
+
+### Step 0 — Consent + frontend-scope gate
+1. Confirm the developer wants a `DESIGN.md` (skip silently if declined — the repo
+   stays baseline-conformant).
+2. **Confirm the repo has a UI surface** (`SPEC.md` §3): look for stylesheets / CSS
+   custom properties, a Tailwind config or `@theme` block, UI components
+   (`.tsx`/`.vue`/`.svelte`/`.astro`), or a token/brand source. If there is **no**
+   UI surface, **stop** and tell the developer this addon does not apply.
+
+### Step 1 — Locate the design source (the part you MUST reason about)
+Find where this repo's design values actually live, using `templates/presets.md`:
+
+- **Tailwind** → `tailwind.config.*` or a Tailwind v4 `@theme {}` block in CSS:
+  theme colors, font families, spacing, radius, screens.
+- **CSS variables / vanilla** → `:root { --… }` custom properties in the global
+  stylesheet; spacing/size scales; media-query breakpoints.
+- **Component library / design tokens** → a `tokens.*` / `theme.*` export, a
+  design-tokens JSON, or a Storybook/theme file.
+- **Brand/style guide** → any `BRAND*.md` / `STYLE*.md` doc, plus accessibility
+  rules documented in `AGENTS.md`/`CLAUDE.md`.
+
+A repo MAY combine sources (a Tailwind config + a brand doc + CSS vars). Read all
+that exist; **the real files win** over any preset assumption.
+
+### Step 2 — Reason out each canonical section
+Using `templates/DESIGN.md.md`, fill each section from the design source:
+Overview/atmosphere · Color palette & roles (light + dark) · Typography · Layout &
+spacing · Elevation & depth · Shapes/radius · Components (in terms of the tokens) ·
+Responsive behavior · Do's & don'ts (incl. the repo's accessibility rules) · Agent
+prompt guide. Express values as **named tokens with usage notes**; add a
+machine-readable token block only if the repo already maintains structured tokens.
+Flag any value you had to **infer** so a human can confirm it.
+
+### Step 3 — Write or reconcile `DESIGN.md`
+- If no `DESIGN.md` exists → write it at the **repo root**.
+- If one already exists → **reconcile additively** (`SPEC.md` §6): keep working
+  values, add missing canonical sections, and ask before any destructive change.
+
+### Step 4 — Validate (the gate)
+Run the validation step (`SPEC.md` §11):
+- All canonical sections present.
+- Every documented value traces to the real design source (spot-check a few
+  against the stylesheet/config); inferred values flagged.
+- Documented text-color pairings meet **WCAG AA** contrast; token references
+  resolve (no orphans/broken refs).
+- File is Markdown-first and compact (~2–5K tokens); no build dependency added.
+
+### Step 5 — (Optional) install the `/design-system` delegator
+If the developer wants a one-command refresh later, install a `/design-system`
+delegator into the repo's `.agents/commands/` (template:
+`templates/design-system-command.md`) that re-runs this addon. Skip if not wanted —
+a declined command leaves a baseline-conformant repo.
+
+## Failure-mode guardrails
+
+- **Never required, never blocking.** If the developer declines, stop cleanly.
+- **Frontend only.** Skip for backend/CLI/non-UI repos — applying it there is a defect.
+- **Reason about the tokens.** Document the repo's real values; never paste a brand file.
+- **Reconcile, don't clobber.** Preserve a working `DESIGN.md`; ask before destructive edits.
+- **Protect accessibility.** Capture the repo's contrast rules; don't document failing pairings.
+- **Reference, don't hard-bind.** Follow the convention's shape, not its Alpha format details.

--- a/skills/deepworkplan/addons/design-system/SPEC.md
+++ b/skills/deepworkplan/addons/design-system/SPEC.md
@@ -1,0 +1,241 @@
+# SPEC.md — Design-System Addon (Normative)
+
+## Abstract
+
+This document is the **normative specification** of the DeepWorkPlan
+**design-system addon**: an opt-in capability that gives a **frontend/UI
+repository** a repo-root **`DESIGN.md`** — a Markdown design-system file that any
+coding agent reads to generate UI **consistent with the repo's own design
+system**. It defines the **frontend-scope gate** (RFC-2119), the **canonical
+sections** a `DESIGN.md` MUST carry, the **reason-don't-copy** rule, the
+**reconcile-don't-clobber** behavior, the **pragmatic-reference** posture toward
+the upstream convention, the **onboarding hook**, and the **validation** step.
+
+The addon is **stack-aware**: it reasons about the repo's **actual** design tokens
+(CSS custom properties, a Tailwind config, design-token files, component styles)
+rather than copying a third-party brand file. It is governed by `../README.md` and
+`methodology-spec/ADDONS.md`: it is **never** required for baseline AI-first
+conformance — a repo with zero addons is fully conformant.
+
+## Status of This Document
+
+| Field | Value |
+|-------|-------|
+| **Version** | 2.0.0 |
+| **Status** | Stable |
+| **Companions** | `SKILL.md`, `templates/DESIGN.md.md`, `templates/presets.md`, `templates/agent_prompt_guide.md`, `../README.md`, `methodology-spec/ADDONS.md` |
+| **License** | MIT |
+
+## 1. Conventions
+
+The RFC 2119 keywords (**MUST**, **MUST NOT**, **SHOULD**, **SHOULD NOT**,
+**MAY**, **OPTIONAL**) are interpreted as in
+[RFC 2119](https://www.rfc-editor.org/rfc/rfc2119).
+
+Throughout, **`DESIGN.md`** is the repo-root design-system file this addon
+produces; a **token** is a named design value (a color, a type size, a spacing
+step, a radius, an elevation); and the **design source** is the repo's real
+origin of those values (a stylesheet, a Tailwind config, a token file, or the
+component styles themselves).
+
+---
+
+## 2. What the Addon Provides
+
+- The addon **MUST** produce a single **`DESIGN.md` at the repository root**: a
+  Markdown file, human-authorable and LLM-legible, that documents the repo's
+  design system so an agent generating UI follows it instead of inventing
+  statistically-common defaults.
+- `DESIGN.md` **MUST** be **co-located with the code** (repo root, version
+  controlled, reviewable in pull requests) — it is repo-native context, the same
+  shape as `AGENTS.md`.
+- The file **SHOULD** stay compact (roughly 2–5K tokens) so it fits comfortably in
+  an agent's context window alongside the task.
+- The addon **MUST NOT** introduce a build dependency, a plugin, or an external
+  source of truth; `DESIGN.md` is plain Markdown readable by any agent.
+
+---
+
+## 3. Frontend-Scope Gate (the part the addon reasons about)
+
+- The addon is **frontend/UI-scoped**. It **MUST** be offered (and applied) only
+  when the repo has a **user-facing UI surface**.
+- The agent **MUST** detect frontend scope from **real files**, e.g.:
+
+  | Signal | Example evidence |
+  |--------|------------------|
+  | Stylesheet / tokens | `*.css`, `*.scss`, CSS custom properties, a `tokens.*` / `theme.*` file |
+  | Utility/theme config | `tailwind.config.*`, a Tailwind v4 `@theme` block in CSS, CSS-in-JS theme |
+  | UI components | `.jsx`/`.tsx`/`.vue`/`.svelte`/`.astro` components, a component library |
+  | Design assets | a brand/style guide doc, a design-tokens export, a Figma reference |
+
+- A repo with **no** UI surface (a pure backend service, a CLI, a library with no
+  rendered output) **MUST** have this addon **skipped**; applying it there is a
+  defect.
+- The addon is **archetype-agnostic** (`ARCHETYPES.md`): it MAY be layered onto an
+  individual repo or onto a UI sub-repo of an orchestrator hub.
+
+### 3.1 Recommendation Strength — Default-On When Detected
+
+This addon is **conditionally default-on**: it is **never** part of the zero-addon
+baseline (a repo with no addons is fully conformant — `ADDONS.md` §2), but when the
+frontend-scope signal above **is** detected, onboarding **SHOULD** actively drive it
+in, not merely list it:
+
+- When a UI surface **is** detected:
+  - In **trust mode**, the `onboard` flow **SHOULD apply** the addon automatically
+    (generate `DESIGN.md`), the same way it applies other detected-and-applicable
+    setup — the developer **MAY** still decline.
+  - In **guided mode**, the flow **MUST** present it as a **strong recommendation**
+    and ask before applying.
+- When a UI surface is **not** detected, the flow **MUST NOT** offer it.
+- Declining **MUST** always remain possible, and a declined addon **MUST** leave a
+  fully baseline-conformant repo. "Default-on when detected" raises the *default*,
+  it does **not** make the addon mandatory.
+
+This places `design-system` in the **strongest conditional tier** among the addons:
+weaker than the stack-agnostic baseline (which it is not part of), but stronger than
+a neutral opt-in — because a repo that *has* a design system almost always benefits
+from capturing it as `DESIGN.md`.
+
+---
+
+## 4. Canonical Sections of `DESIGN.md`
+
+A conformant `DESIGN.md` **MUST** contain the following sections (titles MAY be
+adapted to the repo's voice; the substance MUST be present). Each section is
+**filled by reasoning about the design source**, never copied from a brand file.
+
+1. **Overview / Atmosphere** — brand personality, emotional tone, the design's
+   intent in one short paragraph.
+2. **Color Palette & Roles** — semantic colors (primary, secondary, neutral,
+   surface, accent, state colors) with values **and** their functional role; light
+   and dark variants where the repo supports dark mode.
+3. **Typography** — font families, the type scale (sizes/weights/line-heights), and
+   when each level is used.
+4. **Layout & Spacing** — the spacing scale (base unit + steps), grid/container
+   strategy, and whitespace principles.
+5. **Elevation & Depth** — shadow/surface hierarchy and how depth is expressed.
+6. **Shapes** — border-radius scale and corner language; border/hairline treatment.
+7. **Components** — the repo's key UI patterns (buttons, inputs, cards, nav, …)
+   described in terms of the tokens above, including interaction states.
+8. **Responsive Behavior** — breakpoints and touch-target expectations.
+9. **Do's and Don'ts** — explicit guardrails for agent behavior, including
+   **accessibility constraints** the repo enforces (see §7).
+10. **Agent Prompt Guide** — a short "how to use this file" block telling a
+    downstream agent to follow `DESIGN.md` and how to reference tokens.
+
+- Color/spacing/type values **SHOULD** be expressed as **named tokens** with
+  human-readable usage notes; the file **MAY** additionally carry a
+  machine-readable token block (e.g. front matter) when the repo already maintains
+  structured tokens, but a Markdown-first table is sufficient and preferred for
+  authorability.
+
+---
+
+## 5. Reason, Don't Copy
+
+- Every value in `DESIGN.md` **MUST** be **derived from the repo's real design
+  source** — the stylesheet, Tailwind config, token files, or component styles
+  that actually exist.
+- The addon **MUST NOT** paste a third-party brand's `DESIGN.md` (e.g. a catalog
+  entry for Stripe, Linear, or any other site) into the target repo. Reference
+  catalogs are **inspiration for structure**, never the content.
+- When a value is genuinely undefined in the repo, the addon **SHOULD** infer the
+  most consistent value from existing usage and **MUST** flag it as inferred (so a
+  human can confirm), rather than fabricate an unrelated value.
+
+---
+
+## 6. Reconcile, Don't Clobber
+
+- If a `DESIGN.md` (or an equivalent design-token source) **already exists**, the
+  addon **MUST** reconcile additively — preserving values that already work and
+  bringing the rest toward the canonical-section shape.
+- The addon **MUST NOT** overwrite or delete an existing `DESIGN.md` or token file
+  wholesale. Per `AGENT_PROTOCOL.md`, any destructive change to an existing file
+  **MUST** be approved by the developer first.
+- The addon **MUST** record what it changed (added sections, reconciled values,
+  inferred values flagged for confirmation).
+
+---
+
+## 7. Accessibility & Token Integrity
+
+- The Do's and Don'ts section **MUST** capture the repo's **real accessibility
+  rules** (e.g. WCAG AA contrast targets, approved/forbidden text colors) when the
+  repo documents them, so agents do not regress contrast.
+- Documented color pairings intended for text **SHOULD** meet **WCAG AA** contrast
+  (4.5:1 normal, 3:1 large) and the addon **SHOULD** sanity-check the pairings it
+  documents.
+- Token references inside `DESIGN.md` **MUST** resolve — no orphaned or broken
+  references (a component referencing a token that is not defined).
+
+---
+
+## 8. Pragmatic Reference, Not Hard Binding
+
+- The addon **references** the emerging `DESIGN.md` convention (introduced by
+  Google Stitch; popularized by community catalogs) as the **shape** to follow, but
+  **MUST NOT** hard-bind to that convention's evolving/Alpha format details.
+- DWP's `DESIGN.md` is **Markdown-first**; adopting any specific machine-readable
+  token schema (e.g. W3C Design Tokens front matter) is **OPTIONAL** and applied
+  only when it fits the repo.
+
+---
+
+## 9. Onboarding Hook + Optional `/design-system` Delegator
+
+- The addon's onboarding hook (`SKILL.md`) is offered by `onboard` Phase 7b as an
+  **opt-in** step, **only for frontend repos** (§3), and **MUST NOT** be applied
+  without acceptance. A declined addon leaves a baseline-conformant repo.
+- The addon **MAY** install a `/design-system` delegator command into the target
+  repo's `.agents/commands/` (to regenerate/refresh `DESIGN.md` later; template:
+  `templates/design-system-command.md`). Installing the command is **OPTIONAL**; a
+  declined addon installs **no** command.
+
+---
+
+## 10. Relationship to Per-Feature Design Docs (positioning)
+
+- This addon provides a **repo-level, persistent design-system file**. It is
+  **distinct** from a **per-feature technical design document** (the
+  "requirements → design → tasks" `design.md` of tool-bound spec-driven workflows).
+- DeepWorkPlan deliberately does **not** ship a separate per-feature design-doc
+  archetype: a DWP plan's README (Goal + Context), each task's Context and
+  **Acceptance Criteria**, and the **validation gates** already fulfill the
+  per-feature design role. This addon fills the one gap that role does not cover —
+  durable, repo-native **UI** design context.
+
+---
+
+## 11. Validation Step (run after applying)
+
+The addon is correctly applied when **all** hold:
+
+1. The repo was confirmed to have a **frontend/UI surface** (§3); the addon was
+   **skipped** for non-UI repos.
+2. A `DESIGN.md` exists **at the repo root** with all canonical sections (§4).
+3. Every documented value is **traceable to the repo's real design source** (§5);
+   no third-party brand file was pasted; inferred values are flagged.
+4. An **existing** `DESIGN.md`/token source, if present, was **reconciled** (§6),
+   not clobbered; destructive changes were approved.
+5. Documented text color pairings meet **WCAG AA**; token references **resolve**
+   (no orphans/broken refs) (§7).
+6. The file is Markdown-first and compact; no build dependency was introduced (§2).
+7. If a `/design-system` delegator was offered and accepted, it exists in the
+   repo's `.agents/commands/`; if declined, none was installed (§9).
+
+---
+
+## 12. References
+
+- [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119)
+- `SKILL.md` (the onboarding hook + flow), `templates/*` (reasoning aids)
+- `../README.md` (addon mechanism), `methodology-spec/ADDONS.md` (concept + pointer)
+- `AGENT_PROTOCOL.md` (approval gates), `ARCHETYPES.md` (archetypes)
+- [W3C Design Tokens](https://www.w3.org/community/design-tokens/) (optional token schema)
+
+---
+
+*Part of the DeepWorkPlan methodology v2.0.0, MIT License, by [Dailybot](https://dailybot.com) / dailybotops.*

--- a/skills/deepworkplan/addons/design-system/templates/DESIGN.md.md
+++ b/skills/deepworkplan/addons/design-system/templates/DESIGN.md.md
@@ -1,0 +1,99 @@
+# Reasoning template — `DESIGN.md` skeleton
+
+This is the **annotated skeleton** the addon fills by **reasoning about the target
+repo's real design source** (stylesheet, Tailwind config, token files, component
+styles). The *shape* below is fixed; every *value* is derived from the repo — see
+`SPEC.md` §4–§5. Replace each `> how to fill` note with real content and delete the
+notes. Keep the result compact (~2–5K tokens) and Markdown-first.
+
+> **Do not** paste a third-party brand's `DESIGN.md` here. Reference catalogs are
+> inspiration for structure only.
+
+---
+
+```markdown
+# DESIGN.md — {Project} design system
+
+> Design-system context for AI coding agents. When generating or editing UI in
+> this repo, follow this file. Prefer the named tokens below over ad-hoc values.
+
+## Overview
+> how to fill: one short paragraph — brand personality, tone, the design's intent.
+> Pull from the brand/style guide if one exists; otherwise infer from the UI and flag it.
+
+## Colors
+> how to fill: read the real palette (Tailwind theme colors / CSS `--` vars / token
+> file). List SEMANTIC roles + values + usage. Include dark-mode variants if the repo
+> supports dark mode. Note which pairings are for text (and their contrast).
+
+| Token | Value (light) | Value (dark) | Role / usage |
+|-------|---------------|--------------|--------------|
+| `color.bg` | `#…` | `#…` | Page background |
+| `color.text` | `#…` | `#…` | Primary body text |
+| `color.accent` | `#…` | `#…` | Primary actions / links |
+| `color.muted` | `#…` | `#…` | Secondary text (must meet WCAG AA) |
+| … | | | |
+
+## Typography
+> how to fill: real font families + the type scale (size / weight / line-height) and
+> when each level is used. Source: font config + heading/body styles.
+
+| Level | Family | Size / weight / line-height | Used for |
+|-------|--------|-----------------------------|----------|
+| Display | `…` | `…` | Hero / h1 |
+| Heading | `…` | `…` | h2–h4 |
+| Body | `…` | `…` | Paragraphs |
+| Mono | `…` | `…` | Code |
+
+## Layout & spacing
+> how to fill: base spacing unit + steps, container/grid strategy, whitespace rules.
+
+- Spacing scale: `{base}` → `{steps}`
+- Container / grid: `…`
+- Whitespace principle: `…`
+
+## Elevation & depth
+> how to fill: shadow/surface hierarchy, how depth is expressed (or "flat, hairline
+> rules instead of shadows" if that's the system).
+
+## Shapes
+> how to fill: border-radius scale + corner language; border/hairline treatment.
+
+## Components
+> how to fill: the repo's key UI patterns described IN TERMS OF the tokens above,
+> with interaction states. Cover the components that actually exist.
+
+- **Button (primary):** bg `color.accent`, text `…`, radius `…`, states: hover `…`, focus `…`, disabled `…`
+- **Input:** …
+- **Card / surface:** …
+- **Nav / header:** …
+
+## Responsive behavior
+> how to fill: real breakpoints (from the config) + touch-target expectations.
+
+| Breakpoint | Min width | Notes |
+|------------|-----------|-------|
+| sm | `…` | |
+| md | `…` | |
+| lg | `…` | |
+
+## Do's and Don'ts
+> how to fill: explicit guardrails INCLUDING the repo's accessibility rules
+> (approved/forbidden colors, contrast targets). Pull from AGENTS.md / CLAUDE.md.
+
+- DO use the tokens above; DO keep text contrast at WCAG AA (4.5:1 / 3:1).
+- DON'T introduce new colors/fonts outside this file.
+- DON'T `{repo-specific forbidden patterns}`.
+
+## Agent prompt guide
+> how to fill: see templates/agent_prompt_guide.md — a short "how to use this file"
+> block for downstream agents.
+```
+
+---
+
+## After filling
+
+Run the validation step (`SPEC.md` §11): all sections present; values traceable to
+the repo; inferred values flagged; text pairings meet WCAG AA; token references
+resolve; file compact and Markdown-first.

--- a/skills/deepworkplan/addons/design-system/templates/agent_prompt_guide.md
+++ b/skills/deepworkplan/addons/design-system/templates/agent_prompt_guide.md
@@ -1,0 +1,43 @@
+# Reasoning template — the "Agent Prompt Guide" block
+
+Every `DESIGN.md` ends with a short **Agent Prompt Guide**: a "how to use this file"
+block that tells a downstream coding agent to follow the design system. Adapt the
+wording to the repo, keep it to a few lines, and reference the repo's real token
+names.
+
+---
+
+## Drop-in block (adapt the bracketed parts)
+
+```markdown
+## Agent prompt guide
+
+**For coding agents working in this repo:** this `DESIGN.md` is the source of truth
+for UI. Before generating or editing any UI:
+
+1. **Use the named tokens** in this file (colors, type, spacing, radius) — do not
+   introduce ad-hoc values or new colors/fonts outside it.
+2. **Respect roles** — pick a color by its *role* (e.g. `color.accent` for primary
+   actions), not by eyeballing a hex.
+3. **Keep accessibility** — text pairings must meet the contrast targets in Do's &
+   Don'ts; never use a forbidden color for body text.
+4. **Match component patterns** — reuse the documented Button/Input/Card/Nav
+   patterns and their interaction states.
+5. **When something isn't covered**, choose the option most consistent with the
+   tokens here and note the gap rather than inventing an unrelated style.
+
+Suggested instruction to paste into an agent prompt:
+> "Follow `DESIGN.md` strictly. Build [the UI] using its tokens, roles, and
+>  component patterns; keep text contrast at WCAG AA."
+```
+
+---
+
+## Notes
+
+- Reference the repo's **actual** token names (e.g. `color.accent`, `--color-ink`,
+  `oxblood`) so the guidance is concrete, not generic.
+- If the repo installed a `/design-system` delegator, you MAY mention it here
+  ("run `/design-system` to refresh this file after design changes").
+- Keep this block short — its job is to point agents at the rest of the file, not to
+  repeat it.

--- a/skills/deepworkplan/addons/design-system/templates/design-system-command.md
+++ b/skills/deepworkplan/addons/design-system/templates/design-system-command.md
@@ -1,0 +1,44 @@
+# Template — `/design-system` delegator command (reasoning aid)
+
+This is the **delegator command** the design-system addon **MAY** install into the
+target repo's `.agents/commands/design-system.md` **only when the addon is
+accepted** during `onboard` Phase 7b (or when the addon is run directly) **and** the
+developer wants a one-command way to refresh `DESIGN.md` later. It is a **thin
+delegator**: it carries no logic of its own — it routes to the
+`deepworkplan-addon-design-system` addon, which holds the real flow.
+
+Installing this command is **optional** (`SPEC.md` §9). Fill the placeholders by
+reasoning about the target repo (its real design source and accessibility rules);
+do not copy verbatim. Decline the addon → do **not** install this command.
+
+```markdown
+---
+name: design-system
+description: Create or refresh this repo's root DESIGN.md (design tokens + rules for AI agents) via the DeepWorkPlan design-system addon.
+---
+
+# /design-system
+
+Create or refresh `DESIGN.md` at this repository's root so coding agents generate
+UI consistent with this repo's **own** design system. This command is a **thin
+delegator** to the DeepWorkPlan `deepworkplan-addon-design-system` addon — it does
+not contain the logic itself.
+
+## Steps
+
+1. Invoke the `deepworkplan-addon-design-system` addon (via
+   `/deepworkplan-addon-design-system` or by reading the addon's `SKILL.md`).
+2. Follow the addon's flow: locate this repo's real design source
+   (<e.g. CSS custom properties in `src/styles/global.css` + a Tailwind `@theme`
+   block>), reason out each canonical section of `DESIGN.md` from those tokens,
+   and write or **reconcile** `DESIGN.md` at the repo root.
+3. Run the addon's validation step (sections present, values traceable to the real
+   source, WCAG AA contrast, token references resolve).
+
+## Notes
+
+- Design source for this repo: <fill in — e.g. Tailwind config / CSS vars / token file>.
+- Accessibility rules to enforce: <fill in — e.g. WCAG AA, approved/forbidden text colors>.
+- Reason about the real tokens — never paste a third-party brand's `DESIGN.md`.
+- Reconcile an existing `DESIGN.md`; ask before any destructive change.
+```

--- a/skills/deepworkplan/addons/design-system/templates/presets.md
+++ b/skills/deepworkplan/addons/design-system/templates/presets.md
@@ -1,0 +1,55 @@
+# Reasoning presets — where a repo's design tokens live
+
+Match the row(s) for the **detected stack** as a *starting checklist* for **where to
+read** the repo's real design values, then verify every assumption against the
+actual files. **Detected reality wins** — a repo may combine several sources.
+
+> These presets tell you **where to look**, not **what to write**. The values you
+> document come from the repo (`SPEC.md` §5), never from this file or a brand catalog.
+
+---
+
+## Tailwind (v3 config or v4 `@theme`)
+
+- **Tokens:** `tailwind.config.{js,ts,cjs,mjs}` → `theme` / `theme.extend`
+  (`colors`, `fontFamily`, `fontSize`, `spacing`, `borderRadius`, `boxShadow`,
+  `screens`). For **Tailwind v4**, read the `@theme { --color-…; --font-…; --spacing-…; }`
+  block inside the global CSS instead of a JS config.
+- **Dark mode:** `darkMode` strategy + `dark:` variants in components.
+- **Breakpoints:** `theme.screens` (or `@theme` `--breakpoint-*`).
+- **Components:** utility classes in the components reveal real button/input/card patterns.
+
+## CSS variables / vanilla / SCSS
+
+- **Tokens:** `:root { --… }` (and a `.dark`/`[data-theme]` block) in the global
+  stylesheet — colors, spacing, radius, shadows, font stacks.
+- **Type scale:** heading/body rules; `clamp()` for fluid type.
+- **Breakpoints:** `@media (min-width: …)` query values.
+- **SCSS:** `$variables` / `@use` token partials (`_tokens.scss`, `_variables.scss`).
+
+## Component library / design tokens
+
+- **Tokens:** a `tokens.{json,ts,js}` / `theme.{ts,js}` export, a Style
+  Dictionary / W3C design-tokens file, or a theme provider (`createTheme`, MUI
+  theme, Chakra theme, styled-components `ThemeProvider`).
+- **Components:** the library's component source + stories (Storybook) show variants
+  and states; map these to the Components section.
+- **Reference syntax:** if the repo already uses `{path.to.token}`-style refs, mirror
+  that in `DESIGN.md`; otherwise plain named tokens are fine.
+
+## Brand / style guide + accessibility rules
+
+- **Brand doc:** any `BRAND*.md`, `STYLE*.md`, or design doc — use for the Overview
+  / atmosphere and intent.
+- **Accessibility:** contrast targets and approved/forbidden colors are often in
+  `AGENTS.md` / `CLAUDE.md` / an accessibility doc — these feed the Do's & Don'ts.
+
+---
+
+## Cross-check before writing
+
+1. Did you read the **actual** token source (not a guess)?
+2. Are **dark-mode** values captured if the repo supports dark mode?
+3. Do the **breakpoints** match the real config?
+4. Are the **accessibility** rules reflected in Do's & Don'ts?
+5. Are any **inferred** values flagged for human confirmation?

--- a/skills/deepworkplan/onboard/SKILL.md
+++ b/skills/deepworkplan/onboard/SKILL.md
@@ -370,13 +370,14 @@ After the core AI-first scaffolding, **enumerate** the available addons under
 required** — a repo is fully conformant with zero addons. In **trust mode**, you
 MAY recommend the obviously-applicable ones, but still surface them.
 
-Three addons ship today; enumerate **all** and offer each independently:
+Four addons ship today; enumerate **all** and offer each independently:
 
 | Addon | Folder | Recommend in trust mode when… |
 |-------|--------|-------------------------------|
 | **Devcontainer support** | [`../addons/devcontainer/`](../addons/devcontainer/SKILL.md) | the repo benefits from a reproducible isolated dev container (most repos with Docker/services). |
 | **Dailybot integration** | [`../addons/dailybot/`](../addons/dailybot/SKILL.md) | the developer/team **already uses Dailybot** or asks for team progress reporting — **do NOT auto-install for everyone**. |
 | **Dependency upgrade** | [`../addons/dependency-upgrade/`](../addons/dependency-upgrade/SKILL.md) | the repo has a lockfile + a dependency-heavy stack and wants safe, batched, validated upgrades — recommend only when a lockfile is present; **never auto-install for everyone**. |
+| **Design system** | [`../addons/design-system/`](../addons/design-system/SKILL.md) | **default-on when detected** — whenever the repo has a **UI surface / design system** (a stylesheet with CSS custom properties, a Tailwind config or `@theme` block, UI components, or a brand/style guide), in trust mode **apply** it (generate `DESIGN.md`); in guided mode **strongly recommend** and ask. **Never offer for a backend/CLI/library-only repo.** |
 
 The first addon is **devcontainer support**
 ([`../addons/devcontainer/SKILL.md`](../addons/devcontainer/SKILL.md) +
@@ -430,6 +431,29 @@ batch, revert a failing batch, and summarize. **Only when accepted**, the addon
 installs a `/lib-upgrade` delegator into the repo's `.agents/commands/`. After
 applying, run the addon's validation step (SPEC §9). If declined, skip it — the
 repo stays baseline-conformant and no command is installed.
+
+The fourth addon is **design system**
+([`../addons/design-system/SKILL.md`](../addons/design-system/SKILL.md) +
+[`SPEC.md`](../addons/design-system/SPEC.md)). It is **frontend-scoped** and
+**default-on when detected** (addon SPEC §3.1) — during Phase 1 detection, check
+whether the repo has a **UI surface / design system**: a stylesheet with CSS custom
+properties, a Tailwind config or a Tailwind v4 `@theme {}` block, UI components
+(`.tsx`/`.vue`/`.svelte`/`.astro`), a design-token file, or a brand/style guide.
+When that signal **is** present, do not merely list the addon: in **trust mode
+apply it automatically** (generate `DESIGN.md`, developer may still decline), and in
+**guided mode present it as a strong recommendation** and ask. When the signal is
+**absent**, **do not offer it** (a backend/CLI/library-only repo must never get a
+`DESIGN.md`). Declining always leaves a baseline-conformant repo. If accepted (or
+auto-applied): read that addon's `SKILL.md` and run
+its flow — locate the repo's **real** design source, **reason out** each canonical
+section of `DESIGN.md` from those tokens (Overview/atmosphere, colors & roles incl.
+dark mode, typography, layout & spacing, elevation, shapes, components, responsive
+behavior, do's & don'ts incl. the repo's accessibility rules, agent prompt guide),
+and write `DESIGN.md` at the repo root — **never** copying a third-party brand file.
+An **existing `DESIGN.md`/token source MUST be reconciled, not clobbered**. After
+applying, run the addon's validation step (SPEC §11: sections present, values
+traceable to the real source, WCAG AA contrast, token references resolve). If
+declined, skip it — the repo stays baseline-conformant.
 
 ## Phase 8 — Self-check / validation (mandatory)
 

--- a/skills/deepworkplan/spec/ADDONS.md
+++ b/skills/deepworkplan/spec/ADDONS.md
@@ -97,7 +97,7 @@ An addon **MAY** additionally ship examples, per-stack presets, or migration not
 
 ## 6. Shipping Addons
 
-Two addons ship today. Both are **opt-in** and **never required** — a repository
+Four addons ship today. All are **opt-in** and **never required** — a repository
 is fully conformant with **zero** addons installed.
 
 ### 6.1 Devcontainer Support (first addon)
@@ -156,6 +156,68 @@ is fully conformant with **zero** addons installed.
   never-block rule, vendor-neutral guardrail, validation), and
   `templates/INTEGRATION.md` (reasoning aid).
 
+### 6.3 Dependency Upgrade (third addon)
+
+- **Dependency upgrade** is the **third** addon. Its full normative content (spec,
+  reasoning templates, onboarding hook, validation step, the `/lib-upgrade`
+  delegator template) **MUST** live at:
+
+  ```
+  skills/deepworkplan/addons/dependency-upgrade/
+  ```
+
+- Scope: **package-manager agnostic**, **opt-in** dependency upgrades. When
+  accepted, it detects the repo's **real** package manager (npm/pnpm/yarn + ncu,
+  pip/poetry/uv, cargo, go mod, bundler, composer, …), classifies upgrades by
+  semver, upgrades in **safe batches**, runs the repo's **real** validation gate
+  after each batch, **reverts** a failing batch, and summarizes — and **only when
+  accepted** installs a `/lib-upgrade` delegator into the repo's
+  `.agents/commands/`.
+- The full implementation lives at
+  `skills/deepworkplan/addons/dependency-upgrade/` — see its
+  [`SKILL.md`](../addons/dependency-upgrade/SKILL.md) (onboarding hook),
+  [`SPEC.md`](../addons/dependency-upgrade/SPEC.md) (RFC-2119 contract: detection,
+  semver classification, batched upgrade, validate-after-each-batch gate,
+  revert-on-failure, reconcile-don't-clobber, validation), and `templates/`.
+
+### 6.4 Design System (fourth addon)
+
+- **Design system** is the **fourth** addon. Its full normative content (spec,
+  reasoning templates, onboarding hook, validation step) **MUST** live at:
+
+  ```
+  skills/deepworkplan/addons/design-system/
+  ```
+
+- Scope: a **frontend/UI-scoped**, **opt-in** capability that gives a repo a
+  repo-root **`DESIGN.md`** — a Markdown design-system file any coding agent reads
+  to generate UI consistent with the repo's **own** design system. When accepted,
+  it **reasons about the repo's actual design tokens** (CSS custom properties, a
+  Tailwind config, token files, component styles) — **never** copying a brand file —
+  documents the canonical sections (colors & roles, typography, layout/spacing,
+  elevation, shapes, components, responsive behavior, do's & don'ts, agent prompt
+  guide), checks **WCAG AA** contrast and token integrity, and reconciles an
+  existing `DESIGN.md` instead of clobbering it. It is **default-on when detected**
+  (addon SPEC §3.1): when a UI surface / design system **is** detected the `onboard`
+  flow **applies** it in trust mode and **strongly recommends** it in guided mode;
+  when no UI surface is present it is **not** offered. It remains **never required** —
+  a zero-addon repo is fully conformant.
+- **Distinct from per-feature design docs:** this addon provides a **repo-level,
+  persistent** design-system file; it is **not** a per-feature technical design
+  document (the "requirements → design → tasks" `design.md` of tool-bound
+  spec-driven workflows). DeepWorkPlan deliberately ships **no** separate
+  per-feature design-doc archetype — a plan's README (Goal + Context), each task's
+  Context and **Acceptance Criteria**, and the **validation gates** already fulfill
+  that role; this addon fills the one gap that role does not cover: durable,
+  repo-native **UI** design context.
+- The full implementation lives at
+  `skills/deepworkplan/addons/design-system/` — see its
+  [`SKILL.md`](../addons/design-system/SKILL.md) (onboarding hook),
+  [`SPEC.md`](../addons/design-system/SPEC.md) (RFC-2119 contract: frontend-scope
+  gate, canonical sections, reason-don't-copy, reconcile-don't-clobber,
+  accessibility & token integrity, pragmatic-reference posture, validation), and
+  `templates/` (the `DESIGN.md` skeleton, per-stack presets, agent prompt guide).
+
 > This `ADDONS.md` is the concept + pointer; it **MUST NOT** be treated as any
 > addon's implementation.
 
@@ -168,6 +230,8 @@ is fully conformant with **zero** addons installed.
 - `../RECONCILIATION.md` (divergence #7), `../../ORCHESTRATOR_MANIFEST.md` (devcontainer-addon decision)
 - Devcontainer addon implementation (`skills/deepworkplan/addons/devcontainer/`)
 - Dailybot addon implementation (`skills/deepworkplan/addons/dailybot/`)
+- Dependency-upgrade addon implementation (`skills/deepworkplan/addons/dependency-upgrade/`)
+- Design-system addon implementation (`skills/deepworkplan/addons/design-system/`)
 
 ---
 


### PR DESCRIPTION
## Summary

Adds a fourth opt-in addon, **`design-system`**, that gives a frontend/UI repo a repo-root **`DESIGN.md`** — a Markdown design-system file any coding agent reads to generate UI consistent with the repo's **own** design system (the Google Stitch / `awesome-design-md` convention, adapted to DWP's reason-don't-copy posture).

Motivated by research into whether a `DESIGN.md`-style spec is worth adopting (it is — as a frontend-scoped addon, not a baseline spec). It fits DWP's thesis ("the repository is the harness"): durable, repo-native, tool-agnostic UI context, the same shape as `AGENTS.md`.

## What ships (four-component addon contract)

- **`SPEC.md`** (RFC-2119): frontend-scope gate, the 10 canonical `DESIGN.md` sections, reason-don't-copy, reconcile-don't-clobber, accessibility (WCAG AA) + token integrity, pragmatic-reference posture (references the upstream convention, doesn't hard-bind to its Alpha format), and a validation step.
  - **§3.1 — new "default-on when detected" recommendation tier:** when a UI surface is detected, `onboard` **applies** it in trust mode and **strongly recommends** it in guided mode; a repo with **no** UI surface is **never** offered it; a zero-addon repo stays fully conformant.
- **`SKILL.md`** onboarding hook: consent + scope gate → locate design source → reason out each section → write/reconcile `DESIGN.md` → validate → optional `/design-system` delegator.
- **`templates/`**: `DESIGN.md` skeleton, per-stack presets (where tokens live), agent prompt guide, optional `/design-system` command delegator.

## Registration & positioning

- **`spec/ADDONS.md` §6**: corrects the count to **four** (also adds the previously-missing **dependency-upgrade** entry) and documents `design-system` + the **repo-level-vs-per-feature-design-doc** distinction — DWP deliberately ships **no** per-feature `design.md` archetype (Kiro/Spec-Kit style); a plan's README + each task's acceptance criteria + the validation gates already cover that role.
- **`addons/README.md`**: adds the `design-system` row + prose.
- **`onboard/SKILL.md` Phase 7b**: enumerates four addons; wires `design-system` as default-on when a UI surface / design system is detected.

## Validation

- New `SKILL.md` frontmatter conforms (kebab-case `deepworkplan-addon-design-system`, quoted SemVer `"2.5.0"`, `documentation_url`, boolean `user-invocable`, `allowed-tools`). Verified manually against `scripts/validate-frontmatter.py` rules (PyYAML unavailable in the authoring env to run it directly — please confirm in CI).
- No banned placeholders; all referenced template files present; ship boundary intact (everything under `skills/deepworkplan/`).
- This is additive → **MINOR** bump (`feat(addon):`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)