### PR TITLE
feat(spec): make test & validation discipline a first-class part of the loop

### DIFF
--- a/skills/deepworkplan/create/SKILL.md
+++ b/skills/deepworkplan/create/SKILL.md
@@ -226,7 +226,13 @@ Follow `../guide/GUIDE.md`. Create:
 6. **User-defined task files** — `N.task_{title}.md`, each with Context, Read
    Before Starting (optional), Goal, Instructions (with re-anchoring),
    Acceptance Criteria, Outputs (optional), Validation, Rollback (optional),
-   Execution Checklist, Completion & Log.
+   Execution Checklist, Completion & Log. For any task that adds new core
+   functionality or changes product behavior, bake the **test discipline** into
+   it (`../guide/GUIDE.md` §5.3): its Acceptance Criteria **must** require
+   automated test coverage for the new/changed behavior, and its Validation
+   **must** run the repo's tests plus lint/type-check/format checks (not the
+   build alone). Where related work is substantial, prefer a dedicated
+   `N.task_add_tests_for_{feature}.md` task right after the implementation task.
 
 **Two mandatory final tasks (always):**
 - **Skills & Agents Discovery** (MANDATORY, **second-to-last**, task `N-1`,
@@ -245,7 +251,9 @@ Add to the README a note: "Every plan includes Skills & Agents Discovery
 
 **Quality gates:** atomic, ordered tasks; both mandatory files present;
 `analysis_results/` exists; `PROGRESS.md` exists; numbering correct (user tasks →
-skills discovery → executive report).
+skills discovery → executive report); behavior-changing tasks carry test coverage
+in their Acceptance Criteria and tests + lint/type-check in their Validation
+(`../guide/GUIDE.md` §5.3).
 
 **Accelerate generation with team agents (Claude Code only, automatic):** for
 5+ user-defined task files, the lead creates README/PROMPTS/PROGRESS/

--- a/skills/deepworkplan/execute/SKILL.md
+++ b/skills/deepworkplan/execute/SKILL.md
@@ -79,7 +79,12 @@ Rules (strict):
    instructions and Execution Checklist.
 3. **Run validations** — execute ALL validation commands. If any fail: STOP, log
    the issue in the task's Completion & Log, do NOT mark `[x]`, report and wait
-   for guidance.
+   for guidance. **Test discipline (`../guide/GUIDE.md` §5.3):** if the task added
+   new core functionality or changed product behavior, confirm it added/updated
+   automated tests for that behavior and that validation runs the repo's tests +
+   lint/type-check (not just the build). If a behavior change shipped with no test
+   coverage where the repo supports tests, treat it as an incomplete gate — add the
+   missing tests before marking `[x]`, or log it as a blocker.
 4. **Mark complete** — only when all acceptance criteria are met and all
    validations pass. Update the README `[ ] → [x]` and fill the task's Completion
    & Log (status, timestamp, summary, files changed, validation results, notes).

--- a/skills/deepworkplan/guide/GUIDE.md
+++ b/skills/deepworkplan/guide/GUIDE.md
@@ -343,6 +343,7 @@ Examples:
 - All required functionality is implemented.
 - Code matches the patterns in `docs/ARCHITECTURE.md`.
 - No TypeScript errors are introduced.
+- New or changed behavior is covered by automated tests added or updated in this task (see §5.3).
 - All tests pass (`npm run test`).
 - ESLint checks pass (`npm run eslint:check`).
 - Naming and structure follow existing conventions in `docs/STANDARDS.md`.
@@ -372,6 +373,8 @@ npm run prettier:check
 If any of these fail, the agent must **stop, log the issue, and not mark the task as complete**.
 
 **Note:** The `codecheck` command (from `docker/custom_commands.sh`) runs setup, automatic fixes, and tests in sequence.
+
+For a task that changes product behavior, Validation **must** run the repo's tests **and** its lint/type-check/format checks (the full code-quality check), not the build alone — see §5.3.
 
 ## 8. Rollback (optional)
 
@@ -405,6 +408,39 @@ The agent must append a short log here when the task is done (or blocked):
 - **Notes / follow-ups:**
 ````
 
+### 5.3. Test & Validation Discipline (MANDATORY)
+
+Tests are a first-class part of the loop — they are what makes the code a Deep
+Work Plan ships **reliable** and verifiable, not just "written". This discipline
+applies on every plan, in addition to the per-task validation gates above:
+
+- **New core functionality or changed behavior ⇒ tests.** When a task implements
+  new functionality or materially changes existing behavior, that task **MUST**
+  add or update automated tests covering the new/changed behavior (happy path +
+  meaningful edge/error cases), following the repo's test convention and coverage
+  expectation (`docs/TESTING_GUIDE.md`). Put it in the task's **Acceptance
+  Criteria** so it is checkable.
+- **Run the full code-quality check, not just the build.** A behavior-changing
+  task's **Validation** must run the repo's **tests** *and* its **lint /
+  type-check / format** checks (e.g. `codecheck`, `npm run test && npm run lint`,
+  `pytest && ruff check`). "It builds" / "the file exists" is not a sufficient
+  gate for a behavior change.
+- **Keep existing tests green.** If a change breaks a test that covers the
+  affected code, update the test to reflect the intended new behavior. **Never**
+  delete, skip, or weaken a test just to make the gate pass.
+- **Proportional, not bureaucratic.** Depth of testing scales with the size of the
+  change and the repo's maturity — a one-line fix is not a test suite. Pure docs /
+  config / research tasks are exempt from *creating* tests but still run the repo's
+  validation gate.
+- **No toolchain? It was proposed at onboarding.** If the repo has no test/lint
+  setup, onboarding proposes one fit to the stack and records it in
+  `docs/TESTING_GUIDE.md` (`spec/DOCUMENTATION_STANDARD.md` §3.3). Plans then
+  execute against that — they do not silently skip validation.
+
+> A plan that adds features but ships **zero** test changes is a smell: either the
+> work was not behavior-changing, or the test discipline was skipped. Call it out
+> in the Executive Report rather than hiding it.
+
 ---
 
 ## 6. Agent Execution Rules (Critical Behavior)
@@ -421,6 +457,7 @@ When an agent is instructed to use this system, it must obey:
 
 3. **Validation required**
    - Never mark a task as completed without running and considering the validations defined in the task file.
+   - For behavior-changing tasks, the validations **must** include the repo's tests and its lint/type-check/format checks, and the task must have added/updated tests for the new behavior (§5.3).
 
 4. **Logging & commits**
    - Always update the task's log.

--- a/skills/deepworkplan/onboard/SKILL.md
+++ b/skills/deepworkplan/onboard/SKILL.md
@@ -146,7 +146,12 @@ Detect, by reading actual files (not by habit):
   `codecheck -f` *inside Docker*, `poetry run pytest`, `ruff check`,
   `npm run biome:check`, `astro check`). Note any command that runs **only in
   CI** or **only inside a container** — flag it as such (this matters for the
-  Quick Commands block and the Phase 8 smoke test).
+  Quick Commands block and the Phase 8 smoke test). **If the repo has no test
+  and/or no lint/type-check command at all, do not just record the absence** —
+  flag it as a gap to be closed in Phase 4 by *proposing* a stack-appropriate
+  toolchain (per `../spec/DOCUMENTATION_STANDARD.md` §3.3). Validation gates are
+  the backbone of reliable Deep Work Plans; a repo with no way to validate its
+  behavior is not yet AI-first.
 - **Package manager.** Infer from the **lockfile that actually exists**
   (`pnpm-lock.yaml` → pnpm, `poetry.lock` → poetry, etc.), never from habit.
 - **Folder layout & modules.** Find the source roots (`src/`, `app/`, `lib/`,
@@ -154,7 +159,9 @@ Detect, by reading actual files (not by habit):
   These become the per-module docs in Phase 5.
 - **Test convention.** File naming (`*_test.py`, `*.spec.ts`, `*.test.ts`),
   framework (pytest / jest / vitest / playwright / go test), and where tests
-  live (co-located vs `tests/`).
+  live (co-located vs `tests/`). If **no tests exist**, note that — Phase 4 will
+  *propose* a convention and framework reasoned from the stack rather than
+  leaving testing undefined.
 - **Deployment / runtime shape.** Containerized? Serverless? Static site?
   Long-running service? Library/package? This informs `ARCHITECTURE.md` and
   `PERFORMANCE.md`.
@@ -262,7 +269,15 @@ Each doc must contain **real** content:
   error/logging patterns, and forbidden anti-patterns (carry forward existing
   linter config).
 - `TESTING_GUIDE.md` — the **real** test framework + file-naming pattern + how
-  to run/scope tests + coverage expectation.
+  to run/scope tests + coverage expectation. **If the repo has no test/lint
+  setup, do NOT write "no tests" or leave it empty** — *propose* a
+  stack-appropriate setup (recommended framework + runner, test file convention,
+  where tests live, a sensible initial coverage target, and the lint /
+  type-check / format tooling), document it as the **target**, and surface it to
+  the developer. When non-destructive and the developer consents, scaffold a
+  minimal runnable baseline (the test/lint scripts + at least one real smoke
+  test). See `../spec/DOCUMENTATION_STANDARD.md` §3.3. This is essential, not
+  cosmetic: it is what gives every future Deep Work Plan a real validation gate.
 - `DEVELOPMENT_COMMANDS.md` — the authoritative, **verbatim** command reference
   (install/test/lint/type-check/build/run), expanding the AGENTS.md Quick
   Commands; flag CI/Docker-only commands.
@@ -479,6 +494,8 @@ After generating, run this checklist in the target repo. On any failure,
    (the eight MUST files at minimum — `PRODUCT_SPEC` included — plus
    `docs/README.md`). Grep for leftover
    placeholder markers (`<...>`, "TODO", "your command here") and fix any.
+   **`TESTING_GUIDE.md` MUST describe either a real test/lint setup or a concrete
+   *proposed* one (§3.3)** — never empty, never "no tests".
 4. **Every major source module has a `README.md`** (and complex modules have a
    `docs/`).
 5. **`.agents/`** has `agents/`, `commands/`, `skills/`, `docs/`, `settings.json`
@@ -494,7 +511,10 @@ After generating, run this checklist in the target repo. On any failure,
 7. **Smoke test — run the repo's OWN detected validation command once** to
    confirm recon was accurate (e.g. the lint or test command). If it cannot run
    (e.g. Docker required and unavailable, network-gated CI command), **note why**
-   in the report instead of silently skipping.
+   in the report instead of silently skipping. If the repo had **no** validation
+   toolchain and you proposed (and scaffolded) one, run the proposed test/lint
+   command to confirm the baseline is real; if you only documented the proposal
+   without scaffolding, note it as a recommended follow-up in the report.
 8. **Archetype-specific:** if orchestrator hub, confirm the sub-repo navigation
    index + multi-project commit workflow are documented and `ECOSYSTEM_CONTEXT.md`
    exists.

--- a/skills/deepworkplan/spec/DOCUMENTATION_STANDARD.md
+++ b/skills/deepworkplan/spec/DOCUMENTATION_STANDARD.md
@@ -150,7 +150,7 @@ standard:
 | 0 | `PRODUCT_SPEC.md` | **MUST** | The product spec: the problem the repo solves, who it is for, its key capabilities/features, success criteria, and explicit non-goals — the **why** and **for whom**, not the **how**. Deliberately **non-technical**, high-value context. **Every repository is a product** — even a library, CLI, or internal tool: its consumers and their use cases are its product, and they deserve a non-technical spec. A library that omits this hides the very thing a new agent (or human) most needs to understand first. |
 | 1 | `ARCHITECTURE.md` | **MUST** | System design, components, data flow, key decisions. |
 | 2 | `STANDARDS.md` | **MUST** | Coding conventions, naming, import order, error/logging patterns, forbidden anti-patterns. |
-| 3 | `TESTING_GUIDE.md` | **MUST** | Test framework, file-naming pattern, how to run/scope tests, coverage expectation. |
+| 3 | `TESTING_GUIDE.md` | **MUST** | Test framework, file-naming pattern, how to run/scope tests, coverage expectation. **Where the repo has no test setup, this doc MUST instead specify the *proposed* setup reasoned from the stack** (see §3.3). |
 | 4 | `DEVELOPMENT_COMMANDS.md` | **MUST** | Authoritative command reference (install/test/lint/type-check/build/run), expanding §2.4. |
 | 5 | `SECURITY.md` | **MUST** | Secrets handling, auth model, sensitive-data boundaries, what agents MUST NOT write to docs. |
 | 6 | `PERFORMANCE.md` | **SHOULD** | Performance-critical paths, budgets, profiling guidance. |
@@ -188,6 +188,35 @@ A repository **SHOULD** provide `docs/README.md` as the master index of the
 one-line description, and a "start here" pointer for common tasks. It **MUST** be
 present in the orchestrator hub archetype (the hub's `docs/` is large enough that
 navigation without an index degrades agent performance).
+
+### 3.3. The Testing & Validation Toolchain Is Essential (discover, or propose)
+
+A repository's **test, lint, type-check, and format** toolchain is the backbone of
+the validation gates that make Deep Work Plans reliable (`DWP_SPECIFICATION.md`
+§5.1, §5.1.1). It is therefore **not** part of the optional repo-specific surface to
+record "if present" — establishing it is a conformance concern:
+
+- An onboarding agent **MUST** discover how the repo validates code — its real
+  test runner, test file convention, coverage expectation, and its lint /
+  type-check / format commands — by inspecting manifests, config, and CI, and
+  record the **concrete** values in `TESTING_GUIDE.md`, `DEVELOPMENT_COMMANDS.md`,
+  and the `AGENTS.md` Mandatory Rules + Quick Commands (§2.3, §2.4).
+- Where the repository has **no** testing or linting setup, the agent **MUST NOT**
+  leave `TESTING_GUIDE.md` empty or write "no tests". It **MUST propose** a setup
+  fit to the detected stack — a recommended framework and runner, a test
+  file-naming convention, where tests live, a sensible initial coverage target,
+  and the lint / type-check / format tooling — document that proposal as the
+  **target** in `TESTING_GUIDE.md`, and surface it to the developer. It **SHOULD**
+  scaffold a minimal runnable baseline (the test/lint scripts plus at least one
+  real smoke test) when doing so is non-destructive and the developer consents.
+- The proposal **MUST** be reasoned per repo (§7), proportional to the project's
+  size and maturity, and **MUST NOT** be a generic stub — a tiny CLI does not need
+  the same suite as a service, but every repo deserves a defined way to validate
+  its behavior.
+
+A repository whose `TESTING_GUIDE.md` neither describes a real setup nor specifies
+a concrete proposed one is **not** AI-first conformant: agents would have no
+objective validation gate to run.
 
 ---
 
@@ -299,7 +328,7 @@ this standard or from another repo. An onboarding agent (`AGENT_PROTOCOL.md`)
 
 | Repo-specific value | How the agent reasons about it |
 |---------------------|--------------------------------|
-| **Validation commands** | Derive `test`/`lint`/`type-check`/`build`/`validate` from package manager, lockfiles, CI config (e.g. `codecheck -f` in Docker for Django; `eslint:check && test` for Node; `astro:check` for Astro). |
+| **Validation commands** | Derive `test`/`lint`/`type-check`/`build`/`validate` from package manager, lockfiles, CI config (e.g. `codecheck -f` in Docker for Django; `eslint:check && test` for Node; `astro:check` for Astro). **If the repo has no test/lint commands, propose stack-appropriate ones (§3.3) rather than recording their absence.** |
 | **File paths & structure** | Derive module layout from the actual source tree (`app/` vs `src/` vs `pages/`). |
 | **Test file naming** | Derive from existing tests (`*_test.py`, `*.spec.ts`, `*.test.ts`). |
 | **Stack-specific skills** | Decide which `.agents/skills/` to install based on the stack and the repo's needs. |

--- a/skills/deepworkplan/spec/DWP_SPECIFICATION.md
+++ b/skills/deepworkplan/spec/DWP_SPECIFICATION.md
@@ -177,6 +177,41 @@ and scoped; they **MUST NOT** require human judgment to interpret. The concrete
 commands are repo-specific (see `DOCUMENTATION_STANDARD.md` §7) and **MUST** be
 reasoned about per repo.
 
+When the repository has a test, lint, or type-check toolchain (per
+`DOCUMENTATION_STANDARD.md` §7), a task that changes product behavior **MUST** run
+the relevant suite as part of its validation gate. "It builds" or "the file
+exists" is **NOT** a sufficient gate for a behavior change.
+
+### 5.1.1. Test Discipline — New and Changed Behavior
+
+Tests are a first-class part of the loop, not an optional add-on: they are what
+makes the code a Deep Work Plan ships **reliable** and verifiable. Whenever a task
+implements new core functionality or materially changes existing behavior, the
+agent **MUST**:
+
+- Include, in the task's **Acceptance Criteria**, automated test coverage for the
+  new or changed behavior (the happy path plus the meaningful edge/error cases),
+  following the repository's test convention and coverage expectation
+  (`DOCUMENTATION_STANDARD.md` §2.3, §3.1).
+- Include, in the task's **Validation**, the repository's relevant **tests** *and*
+  its **lint / type-check / format** checks — the full code-quality check the repo
+  defines (e.g. `codecheck`, `npm run test && npm run lint`, `pytest && ruff check`),
+  not the build alone.
+- Keep existing tests **green**: if a behavior change breaks a test that covers the
+  affected code, the agent **MUST** update that test to reflect the intended new
+  behavior — it **MUST NOT** delete, skip, or weaken a test merely to force the gate
+  to pass.
+
+Pure-documentation, configuration, or research tasks are **exempt** from creating
+tests but still **MUST** run whatever validation gate the repo defines. The *depth*
+of testing is **proportional** to the size of the change and the repository's
+maturity (`SHOULD` scale, not `MUST` reach a fixed number); what is non-negotiable
+is that a behavior change ships with the coverage and the green checks the
+repository's standard calls for. Where the repository has **no** test or lint
+toolchain, the agent **MUST NOT** silently skip this discipline — it surfaces the
+gap and relies on the toolchain established or **proposed** during onboarding
+(`DOCUMENTATION_STANDARD.md` §3.1, §7).
+
 ### 5.2. Task Completion Protocol
 
 After passing validation and before advancing, the agent **MUST**, in order:

--- a/skills/deepworkplan/verify/SKILL.md
+++ b/skills/deepworkplan/verify/SKILL.md
@@ -74,6 +74,7 @@ git check-ignore tmp >/dev/null 2>&1 && echo "tmp gitignored: ok" || echo "tmp g
 Then, by reading rather than grepping:
 
 - **Real commands.** Open `AGENTS.md` and confirm the Quick Commands actually correspond to this repo (the real package manager, test, lint, and build commands). Flag any command that could not run here.
+- **Testing toolchain defined.** Open `docs/TESTING_GUIDE.md` and confirm it describes either a **real** test/lint setup (framework, file convention, how to run, coverage expectation) or — for a repo without one — a concrete **proposed** stack-appropriate setup (`../spec/DOCUMENTATION_STANDARD.md` §3.3). An empty file, a generic stub, or "no tests" **fails** this check: the repo then has no objective validation gate for future plans.
 - **Catalog matches disk.** Confirm `.agents/docs/` (the skills/agents catalog) lists exactly the skills, agents, and commands that exist under `.agents/` — no dead links, no missing entries.
 - **Skill resolvable.** Confirm the DeepWorkPlan skill is installed or referenced so its sub-skills can be invoked.
 
@@ -82,6 +83,7 @@ Then, by reading rather than grepping:
 For each plan under `.dwp/plans/PLAN_{name}/`:
 
 - Every task file declares an explicit scope, **acceptance criteria**, and at least one **validation gate** (a runnable command or check).
+- **Test discipline.** Tasks that add new core functionality or change product behavior require automated test coverage in their Acceptance Criteria and run the repo's tests + lint/type-check in their Validation (`DWP_SPECIFICATION.md` §5.1.1). A behavior-changing plan with zero test work is a finding, not a pass.
 - `PROGRESS.md` exists and is updated, so the plan is resumable.
 - The two mandatory final tasks are present — Skills & Agents Discovery and the Executive Report.
 - Tasks re-anchor to the plan goal before executing.


### PR DESCRIPTION
## Summary

Makes **tests and the full code-quality check** an essential, explicit part of the Deep Work Plan loop — closing a gap where testing was only implicitly covered by per-task validation gates. No new mandatory final task (the per-task gates already cover "run on execute"); instead the methodology now requires test creation/maintenance for behavior changes and makes the validation toolchain a conformance concern.

## Two pillars

1. **Create/maintain tests when behavior changes (execution).** A task that adds new core functionality or materially changes behavior MUST include automated test coverage in its *acceptance criteria* and MUST run the repo's tests + lint/type-check/format in its *validation* — not the build alone. Existing tests stay green (update to the intended behavior; never delete/skip to force the gate). Docs/config/research tasks are exempt from *creating* tests but still run the repo's gate. Depth is proportional to the change.
2. **Onboarding establishes or PROPOSES the toolchain.** Onboarding MUST discover the repo's real test/lint/type-check setup; where the repo has none, it MUST propose one fit to the stack and document it as the target in `TESTING_GUIDE.md` (never empty / "no tests"). A repo with no defined way to validate behavior is not yet AI-first.

## Files

- `spec/DWP_SPECIFICATION.md` — new **§5.1.1 Test Discipline** + §5.1 reinforcement.
- `spec/DOCUMENTATION_STANDARD.md` — new **§3.3** (toolchain essential; propose if absent) + `TESTING_GUIDE`/§7 rows.
- `onboard/SKILL.md` — Phases 1, 4, 8 (discover-or-propose; self-check).
- `guide/GUIDE.md` — new **§5.3** + execution rule #3 + task template.
- `create/SKILL.md` — test coverage baked into behavior-changing tasks + quality gates.
- `execute/SKILL.md` — enforce discipline before marking complete.
- `verify/SKILL.md` — conformance check for a defined toolchain + plan check for test coverage.

## Notes

- Markdown/prose only — no frontmatter or `version:` fields edited (auto-release owns them; `feat(...)` → MINOR bump).
- Mirrored on the website (deepworkplan-website) across all 17 languages in a companion PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)