### PR TITLE
docs(spec): bump DWP_SPECIFICATION and DOCUMENTATION_STANDARD to 2.1.0

### DIFF
--- a/skills/deepworkplan/spec/DOCUMENTATION_STANDARD.md
+++ b/skills/deepworkplan/spec/DOCUMENTATION_STANDARD.md
@@ -26,7 +26,7 @@ requirements are called out inline.
 
 | Field | Value |
 |-------|-------|
-| **Version** | 2.0.0 |
+| **Version** | 2.1.0 |
 | **Status** | Stable |
 | **Supersedes** | `PLAN_build_deepworkplan_brand/.../deepworkplan/spec/DOCUMENTATION_STANDARD.md` (v1.0.0) |
 | **Companions** | `DWP_SPECIFICATION.md`, `AGENT_PROTOCOL.md`, `ARCHETYPES.md`, `ADDONS.md` |
@@ -375,4 +375,4 @@ for all complex modules (§4).
 
 ---
 
-*Part of the DeepWorkPlan methodology v2.0.0, MIT License, by [Dailybot](https://dailybot.com) / dailybotops.*
+*Part of the DeepWorkPlan methodology v2.1.0, MIT License, by [Dailybot](https://dailybot.com) / dailybotops.*

--- a/skills/deepworkplan/spec/DWP_SPECIFICATION.md
+++ b/skills/deepworkplan/spec/DWP_SPECIFICATION.md
@@ -26,7 +26,7 @@ inline, especially in §8 (orchestrator).
 
 | Field | Value |
 |-------|-------|
-| **Version** | 2.0.0 |
+| **Version** | 2.1.0 |
 | **Status** | Stable |
 | **Supersedes** | `PLAN_build_deepworkplan_brand/.../deepworkplan/spec/DWP_SPECIFICATION.md` (v1.0.0) |
 | **Companions** | `DOCUMENTATION_STANDARD.md`, `AGENT_PROTOCOL.md`, `ARCHETYPES.md`, `ADDONS.md` |
@@ -322,4 +322,4 @@ sequentially (see `AGENT_PROTOCOL.md`).
 
 ---
 
-*Part of the DeepWorkPlan methodology v2.0.0, MIT License, by [Dailybot](https://dailybot.com) / dailybotops.*
+*Part of the DeepWorkPlan methodology v2.1.0, MIT License, by [Dailybot](https://dailybot.com) / dailybotops.*


### PR DESCRIPTION
## Summary

Follow-up to #14 (test & validation discipline, merged). Bumps the per-document version markers of the two spec docs whose **normative content changed** in that PR, so the doc version no longer claims an unchanged 2.0.0.

- `spec/DWP_SPECIFICATION.md` — gained **§5.1.1 Test Discipline**; version table and methodology footer `2.0.0 → 2.1.0`.
- `spec/DOCUMENTATION_STANDARD.md` — gained **§3.3** (testing/validation toolchain essential; propose if absent); version table and footer `2.0.0 → 2.1.0`.

The other spec docs (`AGENT_PROTOCOL`, `ARCHETYPES`, `ADDONS`, `README`) were not changed and stay at 2.0.0.

## Notes

- **Package SemVer untouched.** No `version:` frontmatter in any `SKILL.md` was edited — the auto-release bot owns those (this `docs:` commit will produce a PATCH on merge).
- Mirrored on the website: the equivalent site spec docs were bumped `Version 1.0 → 1.1` (deepworkplan-website PR #26).

🤖 Generated with [Claude Code](https://claude.com/claude-code)