### PR TITLE
docs(spec): unify spec version to 2.1.0 + onboarding improvements (verify gate, evidence-based scale, idempotent resume)

### DIFF
--- a/skills/deepworkplan/addons/dailybot/SPEC.md
+++ b/skills/deepworkplan/addons/dailybot/SPEC.md
@@ -19,7 +19,7 @@ baseline AI-first conformance.
 
 | Field | Value |
 |-------|-------|
-| **Version** | 2.0.0 |
+| **Version** | 2.1.0 |
 | **Status** | Stable |
 | **Companions** | `SKILL.md`, `templates/INTEGRATION.md`, `../README.md`, `methodology-spec/ADDONS.md` |
 | **License** | MIT |
@@ -201,4 +201,4 @@ A repo is **conformant to this addon** when **all** hold (after acceptance):
 
 ---
 
-*Part of the DeepWorkPlan methodology v2.0.0, MIT License, by [Dailybot](https://dailybot.com) / dailybotops.*
+*Part of the DeepWorkPlan methodology v2.1.0, MIT License, by [Dailybot](https://dailybot.com) / dailybotops.*

--- a/skills/deepworkplan/addons/dependency-upgrade/SPEC.md
+++ b/skills/deepworkplan/addons/dependency-upgrade/SPEC.md
@@ -20,7 +20,7 @@ conformance.
 
 | Field | Value |
 |-------|-------|
-| **Version** | 2.0.0 |
+| **Version** | 2.1.0 |
 | **Status** | Stable |
 | **Companions** | `SKILL.md`, `templates/ecosystems.md`, `templates/upgrade-report.md`, `templates/lib-upgrade-command.md`, `../README.md`, `methodology-spec/ADDONS.md` |
 | **License** | MIT |
@@ -172,4 +172,4 @@ The addon is correctly applied when **all** hold:
 
 ---
 
-*Part of the DeepWorkPlan methodology v2.0.0, MIT License, by [Dailybot](https://dailybot.com) / dailybotops.*
+*Part of the DeepWorkPlan methodology v2.1.0, MIT License, by [Dailybot](https://dailybot.com) / dailybotops.*

--- a/skills/deepworkplan/addons/design-system/SPEC.md
+++ b/skills/deepworkplan/addons/design-system/SPEC.md
@@ -23,7 +23,7 @@ conformance — a repo with zero addons is fully conformant.
 
 | Field | Value |
 |-------|-------|
-| **Version** | 2.0.0 |
+| **Version** | 2.1.0 |
 | **Status** | Stable |
 | **Companions** | `SKILL.md`, `templates/DESIGN.md.md`, `templates/presets.md`, `templates/agent_prompt_guide.md`, `../README.md`, `methodology-spec/ADDONS.md` |
 | **License** | MIT |
@@ -253,4 +253,4 @@ The addon is correctly applied when **all** hold:
 
 ---
 
-*Part of the DeepWorkPlan methodology v2.0.0, MIT License, by [Dailybot](https://dailybot.com) / dailybotops.*
+*Part of the DeepWorkPlan methodology v2.1.0, MIT License, by [Dailybot](https://dailybot.com) / dailybotops.*

--- a/skills/deepworkplan/addons/devcontainer/SPEC.md
+++ b/skills/deepworkplan/addons/devcontainer/SPEC.md
@@ -17,7 +17,7 @@ The addon is governed by `../README.md` and `methodology-spec/ADDONS.md`: it is
 
 | Field | Value |
 |-------|-------|
-| **Version** | 2.0.0 |
+| **Version** | 2.1.0 |
 | **Status** | Stable |
 | **Companions** | `SKILL.md`, `templates/*` (reasoning templates + 7 presets), `../README.md`, `methodology-spec/ADDONS.md` |
 | **License** | MIT |
@@ -262,4 +262,4 @@ The addon is correctly applied when **all** hold:
 
 ---
 
-*Part of the DeepWorkPlan methodology v2.0.0, MIT License, by [Dailybot](https://dailybot.com) / dailybotops.*
+*Part of the DeepWorkPlan methodology v2.1.0, MIT License, by [Dailybot](https://dailybot.com) / dailybotops.*

--- a/skills/deepworkplan/onboard/SKILL.md
+++ b/skills/deepworkplan/onboard/SKILL.md
@@ -193,6 +193,18 @@ validation commands (flagged CI/Docker-only where relevant), source roots +
 major modules, test convention, deployment shape, carried-forward conventions,
 and which preset you used.
 
+**Also record a scale count** (the evidence the Phase 2b decision reads, so the
+inline-vs-plan choice is mechanical, not guessed):
+
+- `major_modules` — the number of major source modules you'll write per-module
+  docs for (Phase 5).
+- `planned_artifacts` — a rough total of files to generate: `AGENTS.md` (1) +
+  the `docs/` categories (~10) + one per-module `README.md` + the `.agents/` kit.
+  Estimate it: `≈ 11 + major_modules` for a typical repo.
+
+Record both numbers explicitly in `.dwp/onboard/RECON.md`. Phase 2b thresholds
+are stated against these counts.
+
 ## Phase 2 — Archetype decision
 
 Classify the repo using `../spec/ARCHETYPES.md` signals (summarized in
@@ -232,19 +244,29 @@ becomes its own Deep Work Plan** — the repo's first plan is "finish onboarding
 myself," executed task-by-task with gates and full resumability. This is the
 methodology dogfooding itself: the onboarding uses the very loop it installs.
 
-**Decide the strategy from recon (reason, don't default).** Choose
+**Decide the strategy from the recon counts (mechanical, not a guess).** Read the
+`major_modules` and `planned_artifacts` numbers you recorded in Phase 1. Choose
 **plan-driven** when a clear majority of these hold (or the developer asks):
 
-- More than ~8 major modules needing their own per-module docs (Phase 5).
+- `major_modules` **> 8** (each needs its own per-module doc, Phase 5).
+- `planned_artifacts` **≥ 15** (docs + per-module docs + `.agents/`).
 - A monorepo / multi-package workspace, or an orchestrator hub.
-- Docs + per-module docs + `.agents/` add up to ~15+ artifacts to generate.
 - The work plainly won't fit one focused session, or must survive across
   sessions/agents.
 
-Otherwise stay **inline** (the typical case) — run Phases 3–8 directly.
+Otherwise stay **inline** (the typical case) — run Phases 3–8 directly. State the
+counts and the resulting choice in `.dwp/onboard/RECON.md` so the decision is
+auditable; if the counts sit right at the boundary, present them and let the
+developer break the tie.
 
 **The plan-driven path:**
 
+0. **Resume, don't regenerate (idempotency check).** Before building a new plan,
+   look for an in-progress onboarding plan: `ls .dwp/plans/PLAN_onboard_*`. If one
+   exists, **do not start over** — read its `PROGRESS.md`, report status, and hand
+   off to `/dwp-resume` to continue from the first open task. Only generate a new
+   plan when none exists. (This honors the Phase 0 idempotency rule for the
+   plan-driven path and matches the `verify` sub-skill's in-progress note.)
 1. Still complete **Phase 1 recon** and **Phase 2 archetype** here — the recon
    (`.dwp/onboard/RECON.md`) is the analysis the plan is built from. Never skip
    it.
@@ -594,7 +616,15 @@ done.
 8. **Archetype-specific:** if orchestrator hub, confirm the sub-repo navigation
    index + multi-project commit workflow are documented and `ECOSYSTEM_CONTEXT.md`
    exists.
-9. **Write the onboarding report** to `.dwp/onboard/REPORT.md` summarizing: the
+9. **Objective conformance gate — run `/dwp-verify`.** This checklist mirrors the
+   `verify` sub-skill; close the loop by actually running it (read
+   [`../verify/SKILL.md`](../verify/SKILL.md) and execute its repository checks)
+   for an independent **CONFORMANT / NOT CONFORMANT** verdict. This dogfoods
+   `verify` and turns the manual checklist into a reproducible gate. Treat a
+   `NOT CONFORMANT` verdict as a Phase 8 failure: **fix-then-recheck** before
+   reporting done. (On the plan-driven path, `/dwp-verify` is exactly the final
+   task's gate.)
+10. **Write the onboarding report** to `.dwp/onboard/REPORT.md` summarizing: the
    archetype chosen + evidence, the detected stack + package manager, the exact
    validation commands captured, the full list of files/folders generated or
    modified, addons accepted/declined, the smoke-test result, any symlink

--- a/skills/deepworkplan/spec/ADDONS.md
+++ b/skills/deepworkplan/spec/ADDONS.md
@@ -19,7 +19,7 @@ implementations. It does **not** contain any addon's implementation.
 
 | Field | Value |
 |-------|-------|
-| **Version** | 2.0.0 |
+| **Version** | 2.1.0 |
 | **Status** | Stable |
 | **Supersedes** | (net-new in v2; no v1 equivalent) |
 | **Companions** | `DOCUMENTATION_STANDARD.md`, `DWP_SPECIFICATION.md`, `AGENT_PROTOCOL.md`, `ARCHETYPES.md` |
@@ -237,4 +237,4 @@ is fully conformant with **zero** addons installed.
 
 ---
 
-*Part of the DeepWorkPlan methodology v2.0.0, MIT License, by [Dailybot](https://dailybot.com) / dailybotops.*
+*Part of the DeepWorkPlan methodology v2.1.0, MIT License, by [Dailybot](https://dailybot.com) / dailybotops.*

--- a/skills/deepworkplan/spec/AGENT_PROTOCOL.md
+++ b/skills/deepworkplan/spec/AGENT_PROTOCOL.md
@@ -20,7 +20,7 @@ through its own native convention. The protocol applies to **both archetypes**
 
 | Field | Value |
 |-------|-------|
-| **Version** | 2.0.0 |
+| **Version** | 2.1.0 |
 | **Status** | Stable |
 | **Supersedes** | `PLAN_build_deepworkplan_brand/.../deepworkplan/spec/AGENT_PROTOCOL.md` (v1.0.0) |
 | **Companions** | `DOCUMENTATION_STANDARD.md`, `DWP_SPECIFICATION.md`, `ARCHETYPES.md`, `ADDONS.md` |
@@ -149,4 +149,4 @@ generated documentation. See `RECONCILIATION.md` non-divergences.
 
 ---
 
-*Part of the DeepWorkPlan methodology v2.0.0, MIT License, by [Dailybot](https://dailybot.com) / dailybotops.*
+*Part of the DeepWorkPlan methodology v2.1.0, MIT License, by [Dailybot](https://dailybot.com) / dailybotops.*

--- a/skills/deepworkplan/spec/ARCHETYPES.md
+++ b/skills/deepworkplan/spec/ARCHETYPES.md
@@ -15,7 +15,7 @@ repository, and how onboarding differs between them. Every other spec
 
 | Field | Value |
 |-------|-------|
-| **Version** | 2.0.0 |
+| **Version** | 2.1.0 |
 | **Status** | Stable |
 | **Supersedes** | (net-new in v2; no v1 equivalent) |
 | **Companions** | `DOCUMENTATION_STANDARD.md`, `DWP_SPECIFICATION.md`, `AGENT_PROTOCOL.md`, `ADDONS.md` |
@@ -130,4 +130,4 @@ following signals hold; otherwise it **MUST** classify it as an **individual rep
 
 ---
 
-*Part of the DeepWorkPlan methodology v2.0.0, MIT License, by [Dailybot](https://dailybot.com) / dailybotops.*
+*Part of the DeepWorkPlan methodology v2.1.0, MIT License, by [Dailybot](https://dailybot.com) / dailybotops.*

--- a/skills/deepworkplan/spec/README.md
+++ b/skills/deepworkplan/spec/README.md
@@ -1,7 +1,7 @@
-# DeepWorkPlan Methodology Specification — v2.0.0
+# DeepWorkPlan Methodology Specification — v2.1.0
 
 > The canonical normative standard for an **AI-first autopilot repository** and the
-> **Deep Work Plan (DWP)** workflow. Version **2.0.0**. This v2 spec **supersedes**
+> **Deep Work Plan (DWP)** workflow. Version **2.1.0**. This v2 spec **supersedes**
 > the v1 baseline specs in `PLAN_build_deepworkplan_brand/.../deepworkplan/spec/`
 > (and the upstream `repo-ready/` and `opensource` drafts). Reconciled from that
 > baseline plus the 6 (+1) new ideas per `../RECONCILIATION.md`.
@@ -32,6 +32,15 @@ orchestrator hub — are addressed throughout.
 7. **Opt-in addons** mechanism, devcontainer first (idea #7).
 8. Version **1.0.0 → 2.0.0** (major, breaking).
 
+## Minor revisions in 2.1.0
+
+- **Test & validation discipline made first-class** (minor, additive): tasks that
+  add or change product behavior MUST carry automated test coverage in their
+  acceptance criteria and run the repo's tests + lint/type-check in their
+  validation gate (`DWP_SPECIFICATION.md` §5.1.1); onboarding MUST define a real
+  or proposed test/lint toolchain so every future plan has an objective gate
+  (`DOCUMENTATION_STANDARD.md` §3.3).
+
 ---
 
-*DeepWorkPlan methodology v2.0.0, MIT License, by [Dailybot](https://dailybot.com) / dailybotops.*
+*DeepWorkPlan methodology v2.1.0, MIT License, by [Dailybot](https://dailybot.com) / dailybotops.*


### PR DESCRIPTION
Follow-up to #16 (merged → released **v2.9.0**). Two logically separate changes.

## 1. `docs(spec)` — unify methodology spec version to 2.1.0

The 2.1.0 spec bump (test & validation discipline) only landed in `DWP_SPECIFICATION.md` and `DOCUMENTATION_STANDARD.md`, leaving the rest of the **single-versioned** methodology spec still declaring **v2.0.0**. The spec README frames the standard as one coherent version, so the split was an inconsistency.

Brings the remaining docs to 2.1.0 (`| Version |` row + `Part of the DeepWorkPlan methodology vX` footer):
- `spec/README.md` (header + intro + footer) + a short **"Minor revisions in 2.1.0"** note explaining the change.
- `spec/ADDONS.md`, `spec/AGENT_PROTOCOL.md`, `spec/ARCHETYPES.md`.
- `addons/{devcontainer,dailybot,dependency-upgrade,design-system}/SPEC.md`.

> Methodology-spec version axis only. The **skill-pack** version (2.9.0, auto-managed in `SKILL.md` frontmatter) is untouched and correct — the two axes are independent.

## 2. `feat(onboard)` — three improvements on the 2.9.0 plan-driven onboarding

- **A) Phase 8 runs `/dwp-verify`.** The self-check now executes the `verify` sub-skill for an objective CONFORMANT / NOT CONFORMANT verdict (both inline and plan-driven paths) — a reproducible gate instead of a manual checklist, and it dogfoods `verify`.
- **B) Evidence-based Phase 2b.** Recon now records `major_modules` and `planned_artifacts`; the inline-vs-plan decision reads them mechanically (`major_modules > 8` or `planned_artifacts >= 15`) instead of guessing, auditable in `RECON.md`, with a developer tie-break at the boundary.
- **C) Idempotent plan-driven path.** Before building a new onboarding plan, detect an in-progress `PLAN_onboard_*` and **resume** via `/dwp-resume` rather than regenerating — honoring the Phase 0 idempotency rule and matching verify's in-progress note.

Additive and backward-compatible; no slash command, `.dwp/` convention, or `SKILL.md` frontmatter changes.

## Verification

- No `version:` frontmatter or `CHANGELOG.md` hand-edits (bot-owned). `feat(onboard)` → MINOR bump on merge (2.9.0 → 2.10.0); spec docs stay at their own 2.1.0.
- New markdown links resolve (`../verify/SKILL.md`, `templates/onboarding-plan.md`) for CI `markdown-link-check`.
- No shell or `skills/`-frontmatter changed → `validate-frontmatter.py`/`shellcheck`/`bats` results unchanged. Ship boundary intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)