### PR TITLE
feat(addon): dailybot plan lifecycle event model — kickoff, blocked, and state-derived payloads

### DIFF
--- a/skills/deepworkplan/addons/dailybot/SKILL.md
+++ b/skills/deepworkplan/addons/dailybot/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: deepworkplan-addon-dailybot
-description: Optional DeepWorkPlan addon that connects an AI-first repo to the developer's Dailybot team — installing (with consent) the Dailybot agent skill and/or the Dailybot CLI, and wiring a best-effort progress/milestone report into DWP execution so a plan completion surfaces to the team. Opt-in, never required, never blocks the work, reconciles existing setups instead of clobbering them, and defers all auth to the Dailybot skill's own consent flow. Use when the developer or team already uses Dailybot and wants DWP progress visible to humans.
+description: Optional DeepWorkPlan addon that connects an AI-first repo to the developer's Dailybot team — installing (with consent) the Dailybot agent skill (DailybotHQ/agent-skill) and/or the Dailybot CLI (DailybotHQ/cli), and wiring the plan lifecycle into best-effort agent updates - kickoff when a plan starts, significant task completions, a blocked report when an unattended run halts, and a milestone on plan completion - with payloads derived from the plan's state layer. Opt-in, never required, never blocks the work, reconciles existing setups instead of clobbering them, and defers all auth to the Dailybot skill's own consent flow. Use when the developer or team already uses Dailybot and wants DWP progress visible to humans.
 version: "2.11.0"
 documentation_url: https://deepworkplan.com
 user-invocable: true
@@ -80,9 +80,10 @@ flow applies, defer to it rather than prompting yourself.
   - `npx skills add DailybotHQ/agent-skill` (cross-agent, recommended), or
   - OpenClaw native: `openclaw skills install dailybot`, or
   - `git clone https://github.com/DailybotHQ/agent-skill.git` + run its `setup.sh`.
-- **Dailybot CLI** (the underlying bridge; the skill installs it on first use
-  via its own SHA-256-verified consent flow — you generally do **not** install
-  it separately, but these are the supported paths if asked):
+- **Dailybot CLI** (the underlying bridge, from
+  [`DailybotHQ/cli`](https://github.com/DailybotHQ/cli); the skill installs it
+  on first use via its own SHA-256-verified consent flow — you generally do
+  **not** install it separately, but these are the supported paths if asked):
   - `curl -sSL https://cli.dailybot.com/install.sh | bash` — pair with the
     **checksum/consent verification** the Dailybot skill documents in
     `shared/auth.md` (cross-origin diff + `.sha256` sidecar check; never run it
@@ -103,20 +104,33 @@ credential. Authentication is owned by the Dailybot skill's
 Point the developer at that flow; the skill handles login, profile, and the
 HTTP fallback. If they decline auth, skip reporting — never block.
 
-### Step 3 — Wire the optional progress-report step into DWP execution
+### Step 3 — Wire the plan lifecycle events into DWP execution
 This is the integration value. Reasoning guidance is in
 `templates/INTEGRATION.md` — adapt it to the repo; do not copy verbatim.
 
 - Add a short, clearly-optional note to the repo's DWP execution docs (e.g. the
   generated `AGENTS.md` reporting section and/or `docs/AI_AGENT_COLLAB.md`)
-  stating: **when the Dailybot skill is installed, a DWP plan completion SHOULD
-  emit a Dailybot report** — a **milestone** report via the dailybot `report`
-  sub-skill (`dailybot agent update ... --milestone --json-data ...`),
-  describing **what was built**, never "completed a plan."
-- The step MUST be **best-effort and conditional**: it fires only if the
+  describing the **four lifecycle events** (SPEC §5.1) that fire when the
+  Dailybot skill is installed:
+  1. **Kickoff** (SHOULD, regular) — when a plan is materialized and approved,
+     report *what is being built and why* ("Starting: …").
+  2. **Significant task** (MAY, regular) — a feature/bug fix/major refactor
+     completes; intermediate setup tasks are never reported.
+  3. **Blocked** (SHOULD, regular with `blockers`) — the plan halts on a stop
+     condition and `state.json.blocked` is populated (typical of unattended
+     runs): the team sees *what is stuck and what it needs* in the standup
+     instead of discovering a silent overnight halt.
+  4. **Completion** (SHOULD, the only **milestone**) — via the dailybot
+     `report` sub-skill (`dailybot agent update ... --milestone --json-data
+     ...`), describing **what was built**, never "completed a plan."
+- Where the plan carries the machine-readable state layer
+  (`../../spec/PLAN_STATE.md`), derive the `--json-data` payload from
+  `state.json`: `completed` from completed tasks (phrased as outcomes),
+  `in_progress` from the current task, `blockers` from `state.json.blocked`.
+- Every event MUST be **best-effort and conditional**: it fires only if the
   Dailybot skill/CLI is present and authenticated, and it **MUST NOT block**
-  `execute` if Dailybot is absent, unauthenticated, or unreachable — warn once
-  and continue (see SPEC §Never-block).
+  `create` or `execute` if Dailybot is absent, unauthenticated, or unreachable —
+  warn once and continue (see SPEC §Never-block).
 - Optionally commit a repo identity so every contributor/agent signs reports the
   same way: `.dailybot/profile.json` (or the gitignore-friendly
   `.dailybot_example/profile.json` template) — **never** with a `key` field

--- a/skills/deepworkplan/addons/dailybot/SPEC.md
+++ b/skills/deepworkplan/addons/dailybot/SPEC.md
@@ -19,10 +19,16 @@ baseline AI-first conformance.
 
 | Field | Value |
 |-------|-------|
-| **Version** | 2.1.0 |
+| **Version** | 2.2.0 |
 | **Status** | Stable |
-| **Companions** | `SKILL.md`, `templates/INTEGRATION.md`, `../README.md`, `methodology-spec/ADDONS.md` |
+| **Companions** | `SKILL.md`, `templates/INTEGRATION.md`, `../README.md`, `methodology-spec/ADDONS.md`, `../../spec/PLAN_STATE.md` |
 | **License** | MIT |
+
+> **Additive in 2.2.0.** Reporting grows from a single completion hook into a
+> **plan lifecycle event model** (§5.1): kickoff, significant task, blocked, and
+> completion — with the report's `--json-data` payload derived from the plan's
+> machine-readable state layer (`PLAN_STATE.md`). All events remain opt-in,
+> conditional, and non-blocking; the completion milestone is unchanged.
 
 ## 1. Conventions
 
@@ -33,7 +39,7 @@ The RFC 2119 keywords (**MUST**, **MUST NOT**, **SHOULD**, **SHOULD NOT**,
 Throughout, the **Dailybot skill** is the official agent skill pack
 ([`DailybotHQ/agent-skill`](https://github.com/DailybotHQ/agent-skill)); the
 **Dailybot CLI** is its companion binary
-([`DailyBotHQ/cli`](https://github.com/DailyBotHQ/cli), PyPI `dailybot-cli`).
+([`DailybotHQ/cli`](https://github.com/DailybotHQ/cli), PyPI `dailybot-cli`).
 
 ---
 
@@ -107,37 +113,67 @@ with explicit acceptance, and each reconciled if already present (§7):
 
 ---
 
-## 5. The Integration Value — Optional Progress/Milestone Reporting
+## 5. The Integration Value — The Plan Lifecycle Event Model
 
-This is the "why": when present, DWP **execution reports progress/milestones to
-the developer's Dailybot team**.
+This is the "why": when present, the **full DWP plan lifecycle surfaces to the
+developer's Dailybot team** as standup-style agent updates — what is starting,
+what is progressing, what is stuck, and what shipped.
 
-### 5.1 What gets wired
+### 5.1 The four lifecycle events
 
-- The addon **MUST** wire a clearly-**optional** report step into the repo's DWP
-  execution documentation (the generated `AGENTS.md` reporting section and/or
-  `docs/AI_AGENT_COLLAB.md`), describing: **when the Dailybot skill is installed,
-  a DWP plan completion SHOULD emit a Dailybot report.**
-- A **DWP plan completion** **SHOULD** be sent as a **milestone** report via the
-  dailybot `report` sub-skill (`dailybot agent update "<what was built>"
-  --milestone --json-data '<completed/in_progress/blockers>' --metadata
-  '<repo/branch/model>'`). Intermediate single-task completions, when reported at
-  all, are **regular** reports, not milestones.
+The addon **MUST** wire a clearly-**optional** report step into the repo's DWP
+execution documentation (the generated `AGENTS.md` reporting section and/or
+`docs/AI_AGENT_COLLAB.md`) describing these events. Every event is conditional
+(§5.3) and non-blocking (§6).
+
+| Event | Trigger | Level | Requirement |
+|-------|---------|-------|-------------|
+| **Kickoff** | A plan is materialized and approved (`create` Step 5), or its first `execute` turn begins | regular | **SHOULD** |
+| **Significant task** | A task that is independently significant completes — a feature, a bug fix, a major refactor (`execute` Step 5). Intermediate setup tasks are **not** reported. | regular | **MAY** |
+| **Blocked** | The plan halts on a stop condition and `state.json.blocked` is populated (`AGENT_PROTOCOL.md` §7.3, `PLAN_STATE.md` §4.4) — typical of unattended runs | regular, with `blockers` populated | **SHOULD** |
+| **Completion** | All tasks `[x]`; the plan finishes (`execute` Step 7) | **milestone** | **SHOULD** |
+
+- The **kickoff** report describes *what is being built and why it matters*
+  ("Starting: …"), giving the team forward visibility — never "created
+  PLAN_x with N tasks".
+- The **blocked** report is the unattended profile's escalation made human: the
+  team sees *what is stuck and what it needs* in the standup channel instead of
+  discovering a silent overnight halt. Its content **MUST** come from
+  `state.json.blocked` (`reason`, `needs`).
+- A plan **completion** is the only **milestone**; every other event is a
+  regular report. A plan **MUST NOT** emit more than one kickoff and one
+  completion report.
+
+### 5.2 Payload — derived from the plan state layer
+
+The report command shape is
+`dailybot agent update "<message>" [--milestone] --json-data
+'<completed/in_progress/blockers>' --metadata '<repo/branch/model>'`.
+
+- When the plan carries the machine-readable state layer (`PLAN_STATE.md`),
+  `--json-data` **SHOULD** be derived from `state.json`: `completed` from the
+  completed tasks (phrased as outcomes, not task numbers), `in_progress` from
+  the task currently `in_progress`, and `blockers` from `state.json.blocked`.
+  The state layer is the single source the payload is projected from — the
+  addon **MUST NOT** invent a second progress-tracking mechanism.
+- Without the state layer, the payload is derived from the plan README's
+  checkbox list. The message and payload **MUST** still follow the writing
+  rules below.
 - Report content **MUST** follow the dailybot `report` writing rules: describe
   **what was built and why**, in English, 1–3 sentences, never "completed a
   plan", never file paths / git stats / branch names / plan IDs.
 
-### 5.2 How `execute` / plan-completion emits it
+### 5.3 How the events are emitted
 
-- The step is **conditional**: it fires **only** when the Dailybot skill/CLI is
-  present and authenticated. The addon **MUST** document the detection check
+- Every event is **conditional**: it fires **only** when the Dailybot skill/CLI
+  is present and authenticated. The addon **MUST** document the detection check
   (e.g. `command -v dailybot`, or the skill installed at
   `~/.<agent>/skills/dailybot/`) and that the report routes through the dailybot
   `report` sub-skill, not a hand-rolled API call.
-- The addon **MUST NOT** change the DWP `execute` public surface; it only adds an
-  optional, conditional reporting hook described in the repo's docs.
+- The addon **MUST NOT** change the DWP `create`/`execute` public surface; it
+  only adds optional, conditional reporting hooks described in the repo's docs.
 - The addon **SHOULD** respect Dailybot's per-repo opt-out
-  (`.dailybot/disabled`): if present, no report is sent.
+  (`.dailybot/disabled`): if present, no report is sent — for any event.
 
 ---
 
@@ -177,8 +213,9 @@ A repo is **conformant to this addon** when **all** hold (after acceptance):
 2. Authentication was **deferred** to the Dailybot skill's `shared/auth.md` — no
    email/OTP/API-key prompting and **no credential** written by this addon.
 3. The repo's DWP execution docs describe the **optional, conditional,
-   non-blocking** report step, sending a **milestone** on plan completion via the
-   dailybot `report` sub-skill.
+   non-blocking** lifecycle events (§5.1): kickoff, significant task, blocked,
+   and the **milestone** on plan completion — all via the dailybot `report`
+   sub-skill, with payloads derived from the plan state layer where present.
 4. If a repo identity was committed, it is credential-free (no `key` field) and
    resolves consistently for all contributors/agents.
 5. Existing skill/CLI/identity/report-step were **reconciled**, not clobbered.
@@ -197,8 +234,9 @@ A repo is **conformant to this addon** when **all** hold (after acceptance):
 - `../README.md` (addon mechanism), [`../../spec/ADDONS.md`](../../spec/ADDONS.md) (concept + pointer)
 - Dailybot skill: [`DailybotHQ/agent-skill`](https://github.com/DailybotHQ/agent-skill)
   — `SKILL.md`, `shared/auth.md`, `report/SKILL.md`
-- Dailybot CLI: [`DailyBotHQ/cli`](https://github.com/DailyBotHQ/cli), PyPI `dailybot-cli`
+- Dailybot CLI: [`DailybotHQ/cli`](https://github.com/DailybotHQ/cli), PyPI `dailybot-cli`
+- [`../../spec/PLAN_STATE.md`](../../spec/PLAN_STATE.md) (the state layer the payloads derive from), `../../spec/AGENT_PROTOCOL.md` §7 (unattended profile + stop conditions)
 
 ---
 
-*Part of the DeepWorkPlan methodology v2.1.0, MIT License, by [Dailybot](https://dailybot.com) / dailybotops.*
+*Part of the DeepWorkPlan methodology v2.2.0, MIT License, by [Dailybot](https://dailybot.com) / dailybotops.*

--- a/skills/deepworkplan/addons/dailybot/templates/INTEGRATION.md
+++ b/skills/deepworkplan/addons/dailybot/templates/INTEGRATION.md
@@ -71,38 +71,67 @@ the developer the Dailybot skill drives this:
 
 ---
 
-## 4. Wire the OPTIONAL report step into DWP execution
+## 4. Wire the plan lifecycle events into DWP execution
 
-The integration value: a **plan completion** emits a **milestone** report when
-Dailybot is present. Reason the exact wording for the repo, then add a short,
-clearly-optional note to the repo's reporting docs (the generated `AGENTS.md`
-reporting section and/or `docs/AI_AGENT_COLLAB.md`). The shape to convey:
+The integration value: the **plan lifecycle surfaces to the team** when
+Dailybot is present (SPEC §5.1). Reason the exact wording for the repo, then
+add a short, clearly-optional note to the repo's reporting docs (the generated
+`AGENTS.md` reporting section and/or `docs/AI_AGENT_COLLAB.md`). The shape to
+convey:
 
 > **Optional — Dailybot reporting (best-effort, never blocks):** when the
-> Dailybot skill/CLI is installed and authenticated, on **DWP plan completion**
-> send a **milestone** report via the dailybot `report` sub-skill, describing
-> what was built. If Dailybot is absent, unauthenticated, or unreachable — or if
-> `.dailybot/disabled` is present — skip silently and continue. Reporting MUST
-> NOT block `execute`.
+> Dailybot skill/CLI is installed and authenticated, DWP work emits agent
+> updates at four points — **kickoff** (plan approved: what is being built),
+> **significant task** (a feature/fix ships mid-plan), **blocked** (the plan
+> halts and `state.json.blocked` says what it needs), and **completion** (the
+> only **milestone**: what was built). If Dailybot is absent, unauthenticated,
+> or unreachable — or if `.dailybot/disabled` is present — skip silently and
+> continue. Reporting MUST NOT block `create` or `execute`.
 
-Reference command shape (the actual content is reasoned from the work, not
+Reference command shapes (the actual content is reasoned from the work, not
 templated; route through the `report` sub-skill when the skill is installed):
 
 ```bash
-# Conditional + best-effort — only when the CLI is present and authed.
+# Guard shared by every event — only when the CLI is present and authed.
 if command -v dailybot >/dev/null 2>&1 && [ ! -f .dailybot/disabled ]; then
+
+  # 1) Kickoff (regular) — plan materialized and approved
+  dailybot agent update "Starting: <what is being built and why it matters>" \
+    --json-data '{"completed":[],"in_progress":["<the goal, as an outcome>"],"blockers":[]}' \
+    --metadata '{"model":"<your-model>","repo":"<repo>","branch":"<branch>"}' \
+    || echo "Dailybot report skipped (non-blocking)."
+
+  # 2) Significant task (regular) — a feature/fix shipped mid-plan
+  dailybot agent update "<what shipped, in plain standup English>" \
+    --json-data '{"completed":["<outcome>"],"in_progress":["<next outcome>"],"blockers":[]}' \
+    || echo "Dailybot report skipped (non-blocking)."
+
+  # 3) Blocked (regular, blockers populated) — derive from state.json.blocked
+  dailybot agent update "<what is stuck and what it needs>" \
+    --json-data '{"completed":["<done so far>"],"in_progress":[],"blockers":["<reason> — needs <needs>"]}' \
+    || echo "Dailybot report skipped (non-blocking)."
+
+  # 4) Completion (the only --milestone)
   dailybot agent update "<what was built, in plain standup English>" \
     --milestone \
     --json-data '{"completed":["..."],"in_progress":[],"blockers":[]}' \
     --metadata '{"model":"<your-model>","repo":"<repo>","branch":"<branch>"}' \
-    || echo "Dailybot report skipped (non-blocking)."  # never fail execute on this
+    || echo "Dailybot report skipped (non-blocking)."
 fi
 ```
 
 Decision notes:
 
-- **Milestone vs regular:** plan completion → `--milestone`. A single mid-plan
-  task, if reported at all, is a regular report (no `--milestone`).
+- **Milestone vs regular:** plan completion → `--milestone`, and nothing else.
+  Kickoff, significant tasks, and blocked are regular reports.
+- **Payload from the state layer:** when the plan carries `state.json`
+  (`PLAN_STATE.md`), derive `--json-data` from it — `completed` from completed
+  tasks phrased as outcomes, `in_progress` from the current task, `blockers`
+  from `state.json.blocked` (`reason`, `needs`). Without the state layer,
+  derive from the plan README's checkboxes. Never maintain a separate progress
+  ledger just for reporting.
+- **One kickoff, one completion** per plan — re-runs and resumes do not
+  re-announce the kickoff.
 - **Writing rules:** describe outcomes + why, English, 1–3 sentences. Never
   "completed a plan", never file paths / git stats / branch names / plan IDs.
   Let the dailybot `report` sub-skill enforce the style.

--- a/skills/deepworkplan/create/SKILL.md
+++ b/skills/deepworkplan/create/SKILL.md
@@ -307,6 +307,14 @@ For a full plan, report success and the location
 sub-skill (`../execute/SKILL.md`); (2) review the README first, then ask again;
 (3) done for now → tell them to run `/dwp-execute {name}` later.
 
+**Dailybot kickoff (only when the Dailybot addon is wired — best-effort,
+non-blocking):** after the plan is materialized and approved, send a **regular**
+(non-milestone) kickoff report via the dailybot `report` sub-skill — "Starting:
+\<what is being built and why it matters\>" — per the addon's lifecycle event
+model (`../addons/dailybot/SPEC.md` §5.1). One kickoff per plan; skip silently
+if Dailybot is absent, unauthenticated, or `.dailybot/disabled` exists. Never
+block on this.
+
 For `refined-draft-only` mode, report the single refined draft saved at
 `.dwp/drafts/PLAN_{name}_draft_refined.md` and the next step: run
 `/dwp-create from PLAN_{name}_draft_refined.md` to build the final plan.

--- a/skills/deepworkplan/execute/SKILL.md
+++ b/skills/deepworkplan/execute/SKILL.md
@@ -125,8 +125,12 @@ passes `trust` / `auto`):
   continue?" between tasks.
 - **Stop only on a real boundary:** a failed validation gate, genuine ambiguity,
   a blocking dependency, an unsafe/destructive action outside the plan's scope, or
-  plan completion. On a stop, log the reason in the task's Completion & Log and
-  report.
+  plan completion. On a stop, log the reason in the task's Completion & Log,
+  populate `state.json.blocked` (task, reason, what it needs), and report.
+  **When the Dailybot addon is wired**, also send a **regular** report with the
+  `blockers` field derived from `state.json.blocked` — the team sees what is
+  stuck and what it needs instead of discovering a silent halt
+  (`../addons/dailybot/SPEC.md` §5.1). Best-effort, never blocks.
 - **Checkpoint every task.** Progress lives on disk — the README checkboxes, each
   task's Completion & Log, and `PROGRESS.md` (summaries, key decisions, important
   values/paths). After each task this state MUST be current, because it is the
@@ -230,8 +234,11 @@ counts, DWP terminology).
 
 Craft it: read the plan README's Goal; summarize WHAT was accomplished in terms
 the team cares about; add WHY it matters; 1–3 sentences; always English; always a
-milestone. The `dailybot` skill is installed alongside this skill — invoke it
-there. If reporting fails, continue without blocking.
+milestone. Where the plan carries the state layer (`../spec/PLAN_STATE.md`),
+derive the report's `--json-data` from `state.json` — `completed` from completed
+tasks phrased as outcomes, `blockers` empty on a clean finish — rather than
+recounting from memory. The `dailybot` skill is installed alongside this skill —
+invoke it there. If reporting fails, continue without blocking.
 
 ### Step 7.1 — Orchestrator Plan Completion
 Report per mode (Distributed: all child DWPs created and ready, with the


### PR DESCRIPTION
## Summary

The Dailybot addon grows from a single completion hook into a **four-event plan lifecycle**, so a team's standup shows the full arc of an agent's work: what is starting, what shipped mid-plan, what is stuck, and what was built.

| Event | Trigger | Level | Requirement |
|-------|---------|-------|-------------|
| **Kickoff** | Plan materialized + approved (`create` Step 5) | regular | SHOULD |
| **Significant task** | Feature/fix/major refactor completes mid-plan | regular | MAY |
| **Blocked** | Plan halts on a stop condition; `state.json.blocked` populated | regular, `blockers` filled | SHOULD |
| **Completion** | All tasks done (`execute` Step 7) | **milestone** (the only one) | SHOULD |

Key design points:

- **Payloads derive from the state layer.** `--json-data` (`completed/in_progress/blockers`) is projected from `state.json` (PLAN_STATE.md) where present — completed tasks phrased as outcomes, `blockers` from `state.json.blocked` (`reason`, `needs`). No second progress ledger.
- **The blocked report is the unattended profile's escalation made human:** an overnight OpenClaw/cloud run that halts surfaces *what it needs* in the standup channel instead of failing silently.
- **Canonical install sources made explicit:** the skill from [`DailybotHQ/agent-skill`](https://github.com/DailybotHQ/agent-skill), the CLI from [`DailybotHQ/cli`](https://github.com/DailybotHQ/cli) (pip `dailybot-cli` / brew / verified installer). Casing fixed (`DailyBotHQ` → `DailybotHQ`).
- **Guarantees unchanged:** opt-in, defer-auth, reconcile-don't-clobber, `.dailybot/disabled` kill-switch, and the never-block rule apply to every event. One kickoff and one completion per plan.

Files: addon `SPEC.md` (2.2.0, additive) · addon `SKILL.md` · `templates/INTEGRATION.md` · `create/SKILL.md` (kickoff hook) · `execute/SKILL.md` (blocked hook + state-derived milestone payload).

## Validation

- `python3 scripts/validate-frontmatter.py` — 13/13 pass
- `bats tests/` — all pass

`feat:` commit → auto-release cuts a MINOR (2.12.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)