### PR TITLE
feat(addon): offer deterministic hook enforcement in the dailybot addon

### DIFF
--- a/skills/deepworkplan/addons/dailybot/SKILL.md
+++ b/skills/deepworkplan/addons/dailybot/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: deepworkplan-addon-dailybot
-description: Optional DeepWorkPlan addon that connects an AI-first repo to the developer's Dailybot team — installing (with consent) the Dailybot agent skill (DailybotHQ/agent-skill) and/or the Dailybot CLI (DailybotHQ/cli), and wiring the plan lifecycle into best-effort agent updates - kickoff when a plan starts, significant task completions, a blocked report when an unattended run halts, and a milestone on plan completion - with payloads derived from the plan's state layer. Opt-in, never required, never blocks the work, reconciles existing setups instead of clobbering them, and defers all auth to the Dailybot skill's own consent flow. Use when the developer or team already uses Dailybot and wants DWP progress visible to humans.
+description: Optional DeepWorkPlan addon that connects an AI-first repo to the developer's Dailybot team — installing (with consent) the Dailybot agent skill (DailybotHQ/agent-skill) and/or the Dailybot CLI (DailybotHQ/cli), wiring the plan lifecycle into best-effort agent updates - kickoff when a plan starts, significant task completions, a blocked report when an unattended run halts, and a milestone on plan completion - with payloads derived from the plan's state layer, and optionally committing the Dailybot skill's deterministic hook enforcement (dailybot hook lifecycle hooks, CLI >= 1.12.0) so the agent harness itself reminds agents about unreported work. Opt-in, never required, never blocks the work, reconciles existing setups instead of clobbering them, and defers all auth to the Dailybot skill's own consent flow. Use when the developer or team already uses Dailybot and wants DWP progress visible to humans.
 version: "2.12.0"
 documentation_url: https://deepworkplan.com
 user-invocable: true
@@ -68,6 +68,8 @@ everyone.
    - A repo identity already committed (`.dailybot/profile.json` or
      `.dailybot_example/profile.json`)?
    - An existing report step already wired into the repo's DWP `execute` notes?
+   - Harness hook configs already carrying `dailybot hook` entries
+     (`.claude/settings.json`, `.agents/settings.json`, `.cursor/hooks.json`, …)?
    If a piece already exists, **do not redo it** — record it and only fill gaps.
 
 ### Step 1 — Offer the Dailybot skill + CLI install (OPT-IN, defer consent)
@@ -134,12 +136,50 @@ This is the integration value. Reasoning guidance is in
 - Optionally commit a repo identity so every contributor/agent signs reports the
   same way: `.dailybot/profile.json` (or the gitignore-friendly
   `.dailybot_example/profile.json` template) — **never** with a `key` field
-  (credentials in that file are a hard error per the CLI).
+  (credentials in that file are a hard error per the CLI). The same file MAY
+  carry the committed report policy the hooks honor:
+  `"report": {"min_interval_minutes": 30, "nudge": true}` (`"nudge": false`
+  is the soft opt-out that keeps manual reporting available).
+
+### Step 3b — Offer deterministic hook enforcement (OPT-IN, defer to the Dailybot skill)
+The lifecycle wiring above is prompt-layer: it relies on the model remembering
+to report. Since Dailybot agent skill **>= 1.6.0** with `dailybot-cli`
+**>= 1.12.0**, the Dailybot skill also ships **deterministic hook enforcement**
+(`report/hooks.md`): harness lifecycle hooks (`dailybot hook session-start |
+activity | post-commit | stop | dismiss`) backed by a local per-repo report
+ledger, so the harness itself detects unreported work and reminds the agent at
+end of turn — even in the long unattended sessions where prompt instructions
+decay. This is the strongest version of the visibility this addon exists for.
+
+- **Offer it** (consent-gated, show the exact config before writing) when the
+  installed Dailybot skill/CLI versions support it: commit the repo-level hook
+  config — Claude Code `.claude/settings.json` (or `.agents/settings.json`
+  where `.claude → .agents`), Cursor `.cursor/hooks.json`, other harnesses per
+  the table in the Dailybot skill's `report/hooks.md` — so every contributor
+  and fresh container gets autonomous reporting on clone; the only per-person
+  step left is `dailybot login`.
+- **Defer the mechanics.** The hook templates, output formats, anti-noise
+  gates, and uninstall path are owned by the Dailybot skill's
+  [`report/hooks.md`](https://github.com/DailybotHQ/agent-skill/blob/main/skills/dailybot/report/hooks.md)
+  — point at it; do not duplicate or hand-roll the JSON beyond merging it in.
+  Merge into existing config files, never overwrite (§Reconcile).
+- **The two layers compose — no double-reporting.** A successful
+  `dailybot agent update` (any lifecycle event from Step 3) resets the hook
+  ledger, so the hooks stay silent after a lifecycle report; they act as the
+  deterministic backstop when a lifecycle event was missed. A hook reminder
+  mid-plan is answered with either a lifecycle-appropriate report or
+  `dailybot hook dismiss` — never ignored, never blocking.
+- **Degrade gracefully.** Older skill/CLI → skip this step (the Step 3 wiring
+  stands alone) and mention `dailybot upgrade` once. The `dailybot hook`
+  commands are local-only and always exit 0, so installing them cannot violate
+  the never-block rule; they also respect `.dailybot/disabled`.
 
 ### Step 4 — Validate (SPEC §Validation)
 Run the validation checklist and report: whether the skill/CLI is present, that
 auth was deferred (not reinvented), that the report step is wired as
-**optional + non-blocking**, the identity source if any, and any deferred items.
+**optional + non-blocking**, whether hook enforcement was offered/installed
+(and the versions that gated it), the identity source if any, and any deferred
+items.
 If nothing could be installed here (sandbox/CI), say why — do not silently skip,
 and do not fail the onboarding.
 

--- a/skills/deepworkplan/addons/dailybot/SPEC.md
+++ b/skills/deepworkplan/addons/dailybot/SPEC.md
@@ -96,6 +96,25 @@ with explicit acceptance, and each reconciled if already present (§7):
   documents).
 - A `key` (credential) field in that file is a **hard error** — the addon
   **MUST NOT** write credentials anywhere.
+- The same file **MAY** carry the committed report policy that the hook layer
+  (§3.4) honors: `"report": {"min_interval_minutes": <n>, "nudge": true|false}`.
+
+### 3.4 Optional harness hook enforcement
+
+- When the installed Dailybot agent skill is **>= 1.6.0** and the Dailybot CLI
+  is **>= 1.12.0**, the addon **SHOULD** offer — and **MAY**, with explicit
+  acceptance, commit — repo-level harness hook configs whose entries invoke the
+  `dailybot hook` lifecycle commands (`session-start`, `activity`,
+  `post-commit`, `stop`), e.g. Claude Code `.claude/settings.json`, Cursor
+  `.cursor/hooks.json`.
+- The hook templates, output dialects, anti-noise gates, and uninstall path are
+  owned by the Dailybot skill's `report/hooks.md` — the addon **MUST** defer to
+  it and **MUST NOT** duplicate or diverge from those templates.
+- The addon **MUST NOT** write hook configs without explicit acceptance, and
+  **MUST** merge into existing config files — never overwrite (§7). Existing
+  `dailybot hook` entries **MUST** be preserved, not duplicated.
+- When versions are older, the addon **MUST** skip this offer (the §5 wiring
+  stands alone) and **MAY** suggest `dailybot upgrade` once.
 
 ---
 
@@ -174,6 +193,12 @@ The report command shape is
   only adds optional, conditional reporting hooks described in the repo's docs.
 - The addon **SHOULD** respect Dailybot's per-repo opt-out
   (`.dailybot/disabled`): if present, no report is sent — for any event.
+- **Synergy with hook enforcement (§3.4):** a successful
+  `dailybot agent update` — any lifecycle event — resets the Dailybot hook
+  ledger, so the two layers never double-report. The hooks are the
+  deterministic backstop for a missed lifecycle event; a hook reminder
+  mid-plan **MUST** be answered with either a lifecycle-appropriate report or
+  `dailybot hook dismiss`, never ignored silently.
 
 ---
 
@@ -186,6 +211,9 @@ The report command shape is
   **not** enter a diagnostic loop. This mirrors the Dailybot skill's own
   non-blocking guarantee.
 - Plan execution **MUST** succeed regardless of whether the report was sent.
+- The `dailybot hook` commands (§3.4) read only local state and always exit
+  `0` by contract, so installing hook enforcement cannot violate this rule;
+  the hooks also honor `.dailybot/disabled` and the committed report policy.
 
 ---
 
@@ -193,8 +221,8 @@ The report command shape is
 
 - The addon **MUST** detect existing setup before acting: an already-installed
   Dailybot skill, a `dailybot` CLI on PATH, a committed `.dailybot/profile.json`
-  / `.dailybot_example/profile.json`, or an existing report step in the repo's
-  DWP docs.
+  / `.dailybot_example/profile.json`, an existing report step in the repo's
+  DWP docs, or harness hook configs already carrying `dailybot hook` entries.
 - Where a piece already exists, the addon **MUST** preserve it and only fill
   gaps — it **MUST NOT** reinstall, re-prompt auth, overwrite a working identity,
   or duplicate the report step.
@@ -233,8 +261,10 @@ A repo is **conformant to this addon** when **all** hold (after acceptance):
 - `SKILL.md` (the onboarding hook + flow), `templates/INTEGRATION.md` (reasoning aid)
 - `../README.md` (addon mechanism), [`../../spec/ADDONS.md`](../../spec/ADDONS.md) (concept + pointer)
 - Dailybot skill: [`DailybotHQ/agent-skill`](https://github.com/DailybotHQ/agent-skill)
-  — `SKILL.md`, `shared/auth.md`, `report/SKILL.md`
+  — `SKILL.md`, `shared/auth.md`, `report/SKILL.md`, `report/hooks.md` (hook
+  enforcement templates, >= 1.6.0)
 - Dailybot CLI: [`DailybotHQ/cli`](https://github.com/DailybotHQ/cli), PyPI `dailybot-cli`
+  — `docs/AGENT_HOOKS.md` (the `dailybot hook` command group + report ledger, >= 1.12.0)
 - [`../../spec/PLAN_STATE.md`](../../spec/PLAN_STATE.md) (the state layer the payloads derive from), `../../spec/AGENT_PROTOCOL.md` §7 (unattended profile + stop conditions)
 
 ---

--- a/skills/deepworkplan/addons/dailybot/templates/INTEGRATION.md
+++ b/skills/deepworkplan/addons/dailybot/templates/INTEGRATION.md
@@ -31,6 +31,9 @@ command -v dailybot >/dev/null 2>&1 && dailybot status --auth 2>&1
 
 # Has Dailybot been disabled for this repo? (respect the opt-out — send nothing)
 ls .dailybot/disabled 2>/dev/null
+
+# Are harness hooks already wired? (the command string is the uninstall marker)
+grep -l 'dailybot hook' .claude/settings.json .agents/settings.json .cursor/hooks.json 2>/dev/null
 ```
 
 Decision notes:
@@ -143,9 +146,45 @@ Decision notes:
 
 ---
 
+## 4b. Offer deterministic hook enforcement (skill >= 1.6.0, CLI >= 1.12.0)
+
+The §4 wiring is prompt-layer — it relies on the model remembering. When the
+installed Dailybot skill/CLI versions support it, also offer (opt-in, show the
+exact config first) to commit the repo-level harness hook config so the harness
+itself reminds the agent about unreported work at end of turn:
+
+```bash
+# Version gate — only offer when both hold
+dailybot --version          # >= 1.12.0 (the `dailybot hook` command group)
+grep -m1 'version:' ~/.*/skills/dailybot/SKILL.md   # >= 1.6.0 (report/hooks.md)
+```
+
+Reason against the repo, then merge (never overwrite) the config the Dailybot
+skill's `report/hooks.md` documents — Claude Code `.claude/settings.json` (or
+`.agents/settings.json` where `.claude → .agents`), Cursor `.cursor/hooks.json`,
+other harnesses per its table. Decision notes:
+
+- **Defer the mechanics** — templates, output formats (`--format claude|cursor|generic`),
+  anti-noise gates, and uninstall all live in the Dailybot skill's
+  `report/hooks.md`; do not duplicate them into the repo docs.
+- **No double-reporting by construction:** every successful
+  `dailybot agent update` (any §4 lifecycle event) resets the hook ledger.
+  The hooks are the deterministic backstop for a missed lifecycle event.
+- **Document the response contract** in the repo's reporting note: a hook
+  reminder is answered with a report (if a meaningful unit is done) or
+  `dailybot hook dismiss` (if not) — never ignored silently, never blocking.
+- **Committed policy knobs** live in `.dailybot/profile.json`:
+  `"report": {"min_interval_minutes": 30, "nudge": false}` turns reminders off
+  for the repo while keeping manual reporting.
+- **Older versions:** skip the offer, suggest `dailybot upgrade` once, and let
+  the §4 wiring stand alone.
+
+---
+
 ## 5. Consent + never-block rules (do not violate)
 
-- **Opt-in:** install nothing and write no identity without explicit acceptance.
+- **Opt-in:** install nothing, write no identity, and commit no hook config
+  without explicit acceptance.
 - **Defer auth:** never prompt for or store credentials; point at the Dailybot
   skill's `shared/auth.md`.
 - **Verified install only:** never recommend `curl ... install.sh | bash`


### PR DESCRIPTION
## Summary

`DailybotHQ/agent-skill` 1.6.0/1.6.1 + `dailybot-cli` 1.12.x shipped **deterministic hook enforcement**: harness lifecycle hooks (`dailybot hook session-start | activity | post-commit | stop | dismiss`) backed by a local per-repo report ledger, so the harness itself detects unreported work and reminds the agent at end of turn — even in the long unattended sessions where prompt instructions decay. That is the strongest version of exactly the visibility this addon exists for, so the addon now offers it on top of the existing prompt-layer lifecycle wiring.

## What changed

- **SKILL.md** — new **Step 3b**: version-gated (skill >= 1.6.0, CLI >= 1.12.0), consent-gated offer to commit the repo-level hook config (Claude Code `settings.json`, Cursor `hooks.json`, …) so reporting travels with the repo (team rollout: only per-person step left is `dailybot login`). All templates/mechanics defer to the Dailybot skill's `report/hooks.md` — same "defer, don't reinvent" rule as auth. Detection checklist (Step 0.2) now includes already-wired hook configs; the `profile.json` offer mentions the committed report policy block (`"report": {"min_interval_minutes": …, "nudge": …}`) the hooks honor. Frontmatter description updated.
- **SPEC.md** — new normative **§3.4**: the addon MAY (with explicit acceptance) commit hook configs, MUST defer to `report/hooks.md`, MUST merge-never-overwrite, MUST skip the offer on older versions. **§5.3** documents the synergy: a successful `dailybot agent update` resets the hook ledger, so the two layers never double-report — the hooks are the deterministic backstop for a missed lifecycle event. **§6** records that `dailybot hook` commands are local-only and always exit 0, so installing them cannot violate never-block. §7 (reconcile detection) and §9 (references) updated.
- **templates/INTEGRATION.md** — detection snippet for existing `dailybot hook` entries (the command string is the uninstall marker), new **§4b** reasoning guidance (version gate, merge rules, the response contract: report or `dailybot hook dismiss`, never ignore silently), consent rule extended to hook configs.

## Why it composes cleanly

The four lifecycle events stay the primary, semantic reporting model; hooks are enforcement underneath, not a replacement. No double-reporting by construction: every lifecycle `agent update` calls `mark_reported()` on the ledger.

## Verification

Dogfooded end-to-end on the deepworkplan-website repo (2026-06-10) with agent-skill 1.6.1 + dailybot-cli 1.12.1: session-start context injection, soft (activity/turns) and strong (commit-count) stop reminders, 15-min nudge cooldown, 30-min min interval, `dismiss` snooze, and ledger reset on a real `agent update`. `python3 scripts/validate-frontmatter.py` passes (13/13).

Additive and opt-in only — no public surface changed (MINOR bump via `feat(addon):`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)