### PR TITLE
chore(skill): refresh dogfood copy to v2.16.1 [skip release]

### DIFF
--- a/.agents/skills/deepworkplan/SKILL.md
+++ b/.agents/skills/deepworkplan/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan
 description: DeepWorkPlan — turn any repo AI-first and run Deep Work Plans. Routes to create, execute, refine, resume, status, verify, and repo-onboarding sub-skills based on intent. Use when the developer wants to plan, execute, manage, or verify structured multi-task work, or make a repository AI-agent-ready.
-version: "2.15.1"
+version: "2.16.1"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write

--- a/.agents/skills/deepworkplan/addons/dailybot/SKILL.md
+++ b/.agents/skills/deepworkplan/addons/dailybot/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-addon-dailybot
 description: Optional DeepWorkPlan addon that connects an AI-first repo to the developer's Dailybot team — installing (with consent) the Dailybot agent skill (DailybotHQ/agent-skill, currently 3.10.3) and/or the Dailybot CLI (DailybotHQ/cli, >= 3.7.0), wiring the plan lifecycle into best-effort agent updates - kickoff when a plan starts, significant task completions, a blocked report when an unattended run halts, and a milestone on plan completion - with payloads derived from the plan's state layer, and optionally committing the Dailybot skill's deterministic hook enforcement (dailybot hook lifecycle hooks) so the agent harness itself reminds agents about unreported work. Opt-in, never required, never blocks the work, reconciles existing setups instead of clobbering them, and defers all auth to the Dailybot skill's own consent flow. Use when the developer or team already uses Dailybot and wants DWP progress visible to humans.
-version: "2.15.1"
+version: "2.16.1"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write

--- a/.agents/skills/deepworkplan/addons/dependency-upgrade/SKILL.md
+++ b/.agents/skills/deepworkplan/addons/dependency-upgrade/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-addon-dependency-upgrade
 description: Optional DeepWorkPlan addon that safely upgrades a repo's dependencies — reasoning about the repo's ACTUAL package manager (npm/pnpm/yarn + ncu, pip/poetry/uv, cargo, go mod, bundler, composer, and more) rather than assuming npm — with a batched, validated, revertible workflow that detects the manager and manifests/lockfiles, classifies upgrades (patch/minor/major), upgrades in safe batches, runs the repo's real validation gate after each batch, reverts a failing batch, and summarizes. Opt-in, never required, reconciles with the repo's existing tooling. Use when the developer wants to bring dependencies up to date without breaking the build.
-version: "2.15.1"
+version: "2.16.1"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write

--- a/.agents/skills/deepworkplan/addons/design-system/SKILL.md
+++ b/.agents/skills/deepworkplan/addons/design-system/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-addon-design-system
 description: Optional DeepWorkPlan addon that gives a repo with a user-facing interface surface a DESIGN.md (under docs/, indexed from AGENTS.md) — a Markdown design-system file any coding agent reads to generate interface output consistent with the repo's OWN conventions. Covers three profiles detected independently from real files — visual-ui (rendered web/mobile/desktop UI), cli-output (styled terminal output — semantic colors, panels, spinners, prompts, TTY/NO_COLOR degradation), and conversational (chat/email messaging — voice and register, message anatomy, per-platform rendering). Reasons about the repo's ACTUAL design source (CSS custom properties, Tailwind config, token files, component styles, a CLI display/theme module, or message-composition helpers) rather than copying a brand file; checks contrast (WCAG AA), color-is-not-the-only-carrier, plain-text fallbacks, and token integrity. The visual-ui profile is default-on when detected (applied in trust mode, strongly recommended in guided mode); cli-output and conversational are recommended when detected and always asked about, never auto-applied. Never offered for a repo with no interface surface (pure library, headless service, infra-only); never required for baseline conformance; reconciles an existing DESIGN.md instead of clobbering it. Use when the developer wants agents to produce on-brand, consistent interface output — visual UI, terminal output, or outbound messages.
-version: "2.15.1"
+version: "2.16.1"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write

--- a/.agents/skills/deepworkplan/addons/devcontainer/SKILL.md
+++ b/.agents/skills/deepworkplan/addons/devcontainer/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-addon-devcontainer
 description: Optional DeepWorkPlan addon that adds (or reconciles) a compose-based devcontainer to a repo — base image and supporting services reasoned from the detected stack, with persistent AI-CLI auth, the dailybot-project-network, the DOCKER_DEV_ENV=vscode convention, and project-identity precedence. Opt-in, never required, reconciles existing setups instead of clobbering them. Use when the developer wants a reproducible isolated dev container for an AI-first repo.
-version: "2.15.1"
+version: "2.16.1"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write

--- a/.agents/skills/deepworkplan/author/SKILL.md
+++ b/.agents/skills/deepworkplan/author/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-author
 description: Author or update reusable skills, agents, and commands in the current repo — reason about the repo's .agents/ layout, follow the Open Agent Skills frontmatter contract, and keep the .agents/docs/ catalog in sync. Use when a developer wants to create or evolve the repo's agent kit (skills, agents, commands), or runs /skill-create or /agent-create.
-version: "2.15.1"
+version: "2.16.1"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write

--- a/.agents/skills/deepworkplan/create/SKILL.md
+++ b/.agents/skills/deepworkplan/create/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-create
 description: Create a Deep Work Plan. Gather context, draft, and refine into a single final plan under .dwp/plans/, with a refined draft staged in .dwp/drafts/. Use when the developer wants a new structured multi-task plan.
-version: "2.15.1"
+version: "2.16.1"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write

--- a/.agents/skills/deepworkplan/execute/SKILL.md
+++ b/.agents/skills/deepworkplan/execute/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-execute
 description: Execute an existing Deep Work Plan task-by-task, run each task's validation, and log progress. Use when the developer wants to run or continue executing a plan in .dwp/plans/.
-version: "2.15.1"
+version: "2.16.1"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write

--- a/.agents/skills/deepworkplan/onboard/SKILL.md
+++ b/.agents/skills/deepworkplan/onboard/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-onboard
 description: Make a repository AI-first by reasoning about its stack and archetype, then generating adapted AGENTS.md, docs/, per-module docs, .agents/, and the .claude/.cursor to .agents symlinks. Offers opt-in addons. Use when the developer wants to onboard or AI-enable a repo.
-version: "2.15.1"
+version: "2.16.1"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write

--- a/.agents/skills/deepworkplan/refine/SKILL.md
+++ b/.agents/skills/deepworkplan/refine/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-refine
 description: Refine a Deep Work Plan draft or modify an existing final plan. Use when the developer wants to adjust scope, tasks, or details of a draft in .dwp/drafts/ or a plan in .dwp/plans/.
-version: "2.15.1"
+version: "2.16.1"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write

--- a/.agents/skills/deepworkplan/resume/SKILL.md
+++ b/.agents/skills/deepworkplan/resume/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-resume
 description: Resume an interrupted Deep Work Plan from its recorded progress state. Use when the developer wants to continue a plan in .dwp/plans/ that was paused or interrupted mid-execution.
-version: "2.15.1"
+version: "2.16.1"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write

--- a/.agents/skills/deepworkplan/status/SKILL.md
+++ b/.agents/skills/deepworkplan/status/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-status
 description: Report the status of a Deep Work Plan — completed tasks, what's left, and blockers — without executing. Use when the developer asks for plan status or what remains.
-version: "2.15.1"
+version: "2.16.1"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write

--- a/.agents/skills/deepworkplan/verify/SKILL.md
+++ b/.agents/skills/deepworkplan/verify/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-verify
 description: Verify that a repository is DeepWorkPlan-conformant (AI-first) and that its plans are well-formed, producing an objective pass/fail report. Use when the developer asks to verify, audit, or check conformance of a repo or a plan.
-version: "2.15.1"
+version: "2.16.1"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob


### PR DESCRIPTION
## Summary

Syncs the dogfooded `.agents/skills/deepworkplan/` mirror with the current canonical `skills/deepworkplan/` tree (**v2.16.1**).

The mirror had lagged at **2.15.1** while releases 2.16.0 and 2.16.1 bumped only the canonical tree. Running the repo's own `scripts/refresh-dogfood-skill.sh` brings the two copies into **full parity**.

### Change
- 13 `version:` fields bumped **2.15.1 → 2.16.1** across the dogfood SKILL.md files
- No content changes — the Dailybot addon content already matched (agent-skill **3.10.3**, CLI **>= 3.7.0**, 14 sub-skills) after PR #29
- `diff -rq skills/deepworkplan .agents/skills/deepworkplan` → full parity

`[skip release]` — mechanical dogfood sync, no user-facing release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)