### PR TITLE
fix(addon): repin the documented AI Diff Reviewer install to v2.0.1 and gate it

### DIFF
--- a/.agents/skills/deepworkplan/SKILL.md
+++ b/.agents/skills/deepworkplan/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan
 description: DeepWorkPlan — turn any repo AI-first and run Deep Work Plans. Routes to create, execute, refine, resume, status, verify, and repo-onboarding sub-skills based on intent. Use when the developer wants to plan, execute, manage, or verify structured multi-task work, or make a repository AI-agent-ready.
-version: "4.0.0"
+version: "4.0.1"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write

--- a/.agents/skills/deepworkplan/addons/ai-diff-reviewer/SKILL.md
+++ b/.agents/skills/deepworkplan/addons/ai-diff-reviewer/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-addon-ai-diff-reviewer
 description: "DeepWorkPlan addon — required local review (baseline since standard 2.3.0), optional CI surface — connects an AI-first repo to the AI Diff Reviewer. Onboarding installs the vendored coding-agent skill and extension with consent; the Final Review runs the local pass when present or records a missing-reviewer finding without bootstrapping. Flow B CI setup remains an explicit opt-in delegated to upstream. Invocation errors never block, completed-review critical findings still follow the Final Review contract, and all install/auth/wizard details defer to upstream consent flows."
-version: "4.0.0"
+version: "4.0.1"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write

--- a/.agents/skills/deepworkplan/addons/ai-diff-reviewer/SKILL.md
+++ b/.agents/skills/deepworkplan/addons/ai-diff-reviewer/SKILL.md
@@ -224,7 +224,7 @@ Run the pinned install unless the developer explicitly declined in Step 0
 
 - **Vendored coding-agent skill** (recommended — brings the five-sub-skill
   router and the byte-identical prompt parity guarantee; current **v2.0.0**):
-  - `npx --yes skills add DailybotHQ/ai-diff-reviewer@v2.0.0 --skill ai-diff-reviewer -y`
+  - `npx --yes skills add DailybotHQ/ai-diff-reviewer@v2.0.1 --skill ai-diff-reviewer -y`
     (**pinned to a published tag**; vendors into
     `.agents/skills/ai-diff-reviewer/` and records source + content hash in
     `skills-lock.json`; both `--yes` and `-y` are required — `--yes` covers

--- a/.agents/skills/deepworkplan/addons/ai-diff-reviewer/SPEC.md
+++ b/.agents/skills/deepworkplan/addons/ai-diff-reviewer/SPEC.md
@@ -143,7 +143,7 @@ acceptance — each reconciled if already present (§8):
 - The addon **MUST** install the vendored skill (the only supported install
   path) unless the developer recorded a declared exception (§2).
   Supported install method:
-  - `npx --yes skills add DailybotHQ/ai-diff-reviewer@v2.0.0 --skill ai-diff-reviewer -y`
+  - `npx --yes skills add DailybotHQ/ai-diff-reviewer@v2.0.1 --skill ai-diff-reviewer -y`
     (**tag-pinned**; both flags are required — `--yes` covers npm's own "Ok to
     proceed?" prompt; the subcommand `-y` covers the `skills` CLI's own "Which
     agents do you want to install to?" picker, which hangs in non-TTY without

--- a/.agents/skills/deepworkplan/addons/ai-diff-reviewer/templates/INTEGRATION.md
+++ b/.agents/skills/deepworkplan/addons/ai-diff-reviewer/templates/INTEGRATION.md
@@ -110,7 +110,7 @@ signalling ("Flow A / Flow B" phrases every subsequent request).
 
 ```bash
 # Tag-pinned install (pin whatever tag is current — this is the reproducible form)
-npx --yes skills add DailybotHQ/ai-diff-reviewer@v2.0.0 --skill ai-diff-reviewer -y
+npx --yes skills add DailybotHQ/ai-diff-reviewer@v2.0.1 --skill ai-diff-reviewer -y
 
 # Verify the vendored version matches the requested tag
 VENDORED=$(sed -nE 's/^version:[[:space:]]*"([^"]+)".*/\1/p' \

--- a/.agents/skills/deepworkplan/addons/dailybot/SKILL.md
+++ b/.agents/skills/deepworkplan/addons/dailybot/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-addon-dailybot
 description: Optional DeepWorkPlan addon that connects an AI-first repo to the developer's Dailybot team — installing (with consent) the Dailybot agent skill (DailybotHQ/agent-skill, currently 3.10.3) and/or the Dailybot CLI (DailybotHQ/cli, >= 3.7.0), wiring the plan lifecycle into best-effort agent updates - kickoff when a plan starts, significant task completions, a blocked report when an unattended run halts, and a milestone on plan completion - with payloads derived from the plan's state layer, and optionally committing the Dailybot skill's deterministic hook enforcement (dailybot hook lifecycle hooks) so the agent harness itself reminds agents about unreported work. Opt-in, never required, never blocks the work, reconciles existing setups instead of clobbering them, and defers all auth to the Dailybot skill's own consent flow. Use when the developer or team already uses Dailybot and wants DWP progress visible to humans.
-version: "4.0.0"
+version: "4.0.1"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write

--- a/.agents/skills/deepworkplan/addons/dependency-upgrade/SKILL.md
+++ b/.agents/skills/deepworkplan/addons/dependency-upgrade/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-addon-dependency-upgrade
 description: Optional DeepWorkPlan addon that safely upgrades a repo's dependencies — reasoning about the repo's ACTUAL package manager (npm/pnpm/yarn + ncu, pip/poetry/uv, cargo, go mod, bundler, composer, and more) rather than assuming npm — with a batched, validated, revertible workflow that detects the manager and manifests/lockfiles, classifies upgrades (patch/minor/major), upgrades in safe batches, runs the repo's real validation gate after each batch, reverts a failing batch, and summarizes. Opt-in, never required, reconciles with the repo's existing tooling. Use when the developer wants to bring dependencies up to date without breaking the build.
-version: "4.0.0"
+version: "4.0.1"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write

--- a/.agents/skills/deepworkplan/addons/design-system/SKILL.md
+++ b/.agents/skills/deepworkplan/addons/design-system/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-addon-design-system
 description: Optional DeepWorkPlan addon that gives a repo with a user-facing interface surface a DESIGN.md (under docs/, indexed from AGENTS.md) — a Markdown design-system file any coding agent reads to generate interface output consistent with the repo's OWN conventions. Covers three profiles detected independently from real files — visual-ui (rendered web/mobile/desktop UI), cli-output (styled terminal output — semantic colors, panels, spinners, prompts, TTY/NO_COLOR degradation), and conversational (chat/email messaging — voice and register, message anatomy, per-platform rendering). Reasons about the repo's ACTUAL design source (CSS custom properties, Tailwind config, token files, component styles, a CLI display/theme module, or message-composition helpers) rather than copying a brand file; checks contrast (WCAG AA), color-is-not-the-only-carrier, plain-text fallbacks, and token integrity. The visual-ui profile is default-on when detected (applied in trust mode, strongly recommended in guided mode); cli-output and conversational are recommended when detected and always asked about, never auto-applied. Never offered for a repo with no interface surface (pure library, headless service, infra-only); never required for baseline conformance; reconciles an existing DESIGN.md instead of clobbering it. Use when the developer wants agents to produce on-brand, consistent interface output — visual UI, terminal output, or outbound messages.
-version: "4.0.0"
+version: "4.0.1"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write

--- a/.agents/skills/deepworkplan/addons/devcontainer/SKILL.md
+++ b/.agents/skills/deepworkplan/addons/devcontainer/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-addon-devcontainer
 description: Optional DeepWorkPlan addon that adds (or reconciles) a compose-based devcontainer to a repo — base image and supporting services reasoned from the detected stack, with persistent AI-CLI auth, the dailybot-project-network, the DOCKER_DEV_ENV=vscode convention, and project-identity precedence. Opt-in, never required, reconciles existing setups instead of clobbering them. Use when the developer wants a reproducible isolated dev container for an AI-first repo.
-version: "4.0.0"
+version: "4.0.1"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write

--- a/.agents/skills/deepworkplan/author/SKILL.md
+++ b/.agents/skills/deepworkplan/author/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-author
 description: Author or update reusable skills, agents, and commands in the current repo — reason about the repo's .agents/ layout, follow the Open Agent Skills frontmatter contract, and keep the .agents/docs/ catalog in sync. Use when a developer wants to create or evolve the repo's agent kit (skills, agents, commands), or runs /skill-create or /agent-create.
-version: "4.0.0"
+version: "4.0.1"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write

--- a/.agents/skills/deepworkplan/create/SKILL.md
+++ b/.agents/skills/deepworkplan/create/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-create
 description: Create a Deep Work Plan for short or long work. Detect planning intent, materialize a compact Lite proposal first, then retain Lite or expand to Full task files when needed. Supports guided and trust handoff without executing product work.
-version: "4.0.0"
+version: "4.0.1"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write

--- a/.agents/skills/deepworkplan/execute/SKILL.md
+++ b/.agents/skills/deepworkplan/execute/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-execute
 description: Execute Lite or Full Deep Work Plans task-by-task — select validation from the actual surface, preserve state and evidence, recover safely, and finish with the Final Review.
-version: "4.0.0"
+version: "4.0.1"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write

--- a/.agents/skills/deepworkplan/onboard/SKILL.md
+++ b/.agents/skills/deepworkplan/onboard/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-onboard
 description: Make any repository AI-first — reason (never template) an adapted AGENTS.md, docs/, per-module docs and .agents/ kit from the real repo, discover and verify its full and scoped validation commands and source-to-test mapping, install the DeepWorkPlan skill, and, for a repository onboarded under an earlier version, perform a targeted, non-destructive, idempotent harness upgrade. Use when the developer wants to onboard or upgrade a repository for AI agents.
-version: "4.0.0"
+version: "4.0.1"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write

--- a/.agents/skills/deepworkplan/onboard/SKILL.md
+++ b/.agents/skills/deepworkplan/onboard/SKILL.md
@@ -136,7 +136,7 @@ mutates the target repository — non-destructively and by explicit design:
 - On the plan-driven path, plan artifacts under `.dwp/` as `create` defines.
 
 **Writes include:** with Phase 0 consent, Phase 7a may run the tag-pinned
-`npx --yes skills add DailybotHQ/ai-diff-reviewer@v2.0.0 --skill ai-diff-reviewer -y`
+`npx --yes skills add DailybotHQ/ai-diff-reviewer@v2.0.1 --skill ai-diff-reviewer -y`
 install into `.agents/skills/ai-diff-reviewer/` and bootstrap the repo-tailored
 `.review/extension.md`; decline or offline failure is recorded as a declared
 exception.

--- a/.agents/skills/deepworkplan/onboard/addons.md
+++ b/.agents/skills/deepworkplan/onboard/addons.md
@@ -20,7 +20,7 @@ and run its flow as a required step, under the Phase 0 onboarding consent:
    > `.github/ai-pr-reviewer/extension.md`), a `.review/.skip-bootstrap`
    marker, and any existing `pr-review.yml`. Fill gaps only.
 2. **Install the vendored skill, pinned:**
-   `npx --yes skills add DailybotHQ/ai-diff-reviewer@v2.0.0 --skill ai-diff-reviewer -y`
+   `npx --yes skills add DailybotHQ/ai-diff-reviewer@v2.0.1 --skill ai-diff-reviewer -y`
    (both `--yes` and `-y` are required in non-TTY; never an unpinned ref, never
    a remote installer piped to a shell). Assert the vendored `SKILL.md` version
    equals the requested tag.

--- a/.agents/skills/deepworkplan/refine/SKILL.md
+++ b/.agents/skills/deepworkplan/refine/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-refine
 description: Refine a Deep Work Plan — safely edit scope, add, split or reorder tasks, promote a Lite plan to Full task files, recover a partial promotion, or explicitly migrate a legacy plan, always preserving completed evidence.
-version: "4.0.0"
+version: "4.0.1"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write

--- a/.agents/skills/deepworkplan/resume/SKILL.md
+++ b/.agents/skills/deepworkplan/resume/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-resume
 description: Resume interrupted Lite or Full Deep Work Plans from durable Markdown and state, including safe recovery of promotions without duplicating completed work or gates.
-version: "4.0.0"
+version: "4.0.1"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write

--- a/.agents/skills/deepworkplan/spec/ADDONS.md
+++ b/.agents/skills/deepworkplan/spec/ADDONS.md
@@ -254,7 +254,7 @@ form**; only its CI surface is optional.
 
 - **Required local review (baseline since standard 2.3.0).** The `onboard` flow
   **MUST** install the vendored coding-agent skill
-  (`npx --yes skills add DailybotHQ/ai-diff-reviewer@v2.0.0 --skill ai-diff-reviewer -y`
+  (`npx --yes skills add DailybotHQ/ai-diff-reviewer@v2.0.1 --skill ai-diff-reviewer -y`
   — **tag-pinned**, both `--yes` and `-y` required) and bootstrap a
   repo-tailored extension file (`.review/extension.md`, via the upstream
   `generate-extension` sub-skill) as part of the baseline scaffolding

--- a/.agents/skills/deepworkplan/status/SKILL.md
+++ b/.agents/skills/deepworkplan/status/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-status
 description: Report Lite or Full Deep Work Plan status — format, approval, readiness, progress, checkpoint, blockers and Markdown/state consistency — without modifying anything.
-version: "4.0.0"
+version: "4.0.1"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob

--- a/.agents/skills/deepworkplan/verify/SKILL.md
+++ b/.agents/skills/deepworkplan/verify/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-verify
 description: Verify that a repository is DeepWorkPlan-conformant (AI-first) and that its plans are well-formed, producing an objective pass/fail report. Use when the developer asks to verify, audit, or check conformance of a repo or a plan.
-version: "4.0.0"
+version: "4.0.1"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -401,6 +401,24 @@ pushes. The `[skip release]` marker prevents an infinite auto-release loop.
   via `scripts/refresh-dogfood-skill.sh` (or an explicit reviewed edit), never
   via release dogfood.
 
+**Pinned install commands are NOT auto-refreshed — and are CI-gated.**
+Release dogfood updates the *vendored copy* under `.agents/skills/`. It does
+**not** rewrite the install commands the shipped pack **teaches** under
+`skills/deepworkplan/`, because those live in prose
+(`npx --yes skills add DailybotHQ/ai-diff-reviewer@vX.Y.Z …`). The two drifted
+apart once — the pack taught `@v2.0.0` while the vendored addon was already
+`2.0.1`, so every repository onboarded from it installed a stale reviewer.
+
+The invariant is now a CI gate: **every exact `ai-diff-reviewer@vX.Y.Z` pin in
+`skills/deepworkplan/` must equal the `version:` of the vendored
+`.agents/skills/ai-diff-reviewer/SKILL.md`** (`tests/agents-dogfood.bats`). When
+a release moves the vendored addon, update the documented pins in the same PR —
+`grep -rn 'ai-diff-reviewer@v[0-9]' skills/` finds them all.
+
+`DailybotHQ/ai-diff-reviewer@v2` (no patch) is a different thing: the **GitHub
+Action's floating major tag**, deliberately left floating so patch fixes flow
+automatically. The gate ignores it. Do not pin it to a patch.
+
 ## Local AI Diff Reviewer
 
 The vendored `ai-diff-reviewer` skill remains available for local reviews

--- a/README.md
+++ b/README.md
@@ -32,6 +32,27 @@ and report with all plan output living in a gitignored
 
 > DeepWorkPlan is spec-driven development where the repository itself becomes the harness.
 
+**What it rests on**
+
+- **You steer; the agents do the hours.** You decide what *done* means and where
+  the lines are. The plan carries your intent, so the work does not need
+  correcting every twenty minutes.
+- **The plan is what the agent returns to.** Long work fills any model's context
+  and detail falls away. Atomic tasks, validation gates and resumable state give
+  the agent something durable to come back to, lap after lap.
+- **Done is a contract, not a feeling.** Every task names its acceptance criteria
+  and the checks that must pass. An agent does not get to *decide* it finished —
+  it passes, or the task stays open.
+- **The repository is the harness.** Context, tools, guardrails and state live in
+  your repo as plain files any agent can read. No lock-in, no external brain, and
+  it survives a context reset or a change of agent mid-flight.
+- **Context is the scarcest resource.** Instructions load progressively by
+  trigger, validation is selected from what each task actually touched, and
+  skills are decided task-locally — so the plan pays for itself instead of
+  crowding out the work.
+
+**At a glance**
+
 - **License:** [MIT](LICENSE)
 - **Security policy:** [SECURITY.md](SECURITY.md)
 - **Changes:** [CHANGELOG.md](CHANGELOG.md)
@@ -48,6 +69,7 @@ and report with all plan output living in a gitignored
 | **deepworkplan-refine** | Modify the scope or tasks of an existing plan, or promote a Lite plan to Full task files. |
 | **deepworkplan-resume** | Resume an interrupted plan from its recorded progress state. |
 | **deepworkplan-status** | Report the status of a plan — completed tasks, what's left, and blockers — without executing. |
+| **deepworkplan-verify** | Check the repository and its plans against the standard — read-only, pass/fail, exits `0`/`1`. Confirms the harness is in place and that every plan's tasks, gates, evidence and final review actually hold, so "done" is auditable rather than asserted. |
 | **deepworkplan-author** | Author or update reusable skills, agents, and commands in the current repo — reasons about the repo's `.agents/` layout, follows the Open Agent Skills frontmatter contract, and keeps the `.agents/docs/` catalog in sync. Backs the `/skill-create` and `/agent-create` aliases. |
 
 A root **deepworkplan** meta-skill acts as a router — it describes all

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -17,7 +17,7 @@
       "source": "DailybotHQ/deepworkplan-skill",
       "sourceType": "github",
       "skillPath": "skills/deepworkplan/SKILL.md",
-      "computedHash": "006755cef89bb3c1b9d93ebe979346ffb4150033f046a6eb4d16ded273bebec1"
+      "computedHash": "6f8eaaee7040a792d08427f7b5fd33e28913211edf6bb86af1ca8661a3b1d9af"
     }
   }
 }

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -17,7 +17,7 @@
       "source": "DailybotHQ/deepworkplan-skill",
       "sourceType": "github",
       "skillPath": "skills/deepworkplan/SKILL.md",
-      "computedHash": "6f8eaaee7040a792d08427f7b5fd33e28913211edf6bb86af1ca8661a3b1d9af"
+      "computedHash": "a29ee6054373abdedaa641dab6826e75bdf6b04b50e483a5222cd786cd9b88ee"
     }
   }
 }

--- a/skills/deepworkplan/addons/ai-diff-reviewer/SKILL.md
+++ b/skills/deepworkplan/addons/ai-diff-reviewer/SKILL.md
@@ -224,7 +224,7 @@ Run the pinned install unless the developer explicitly declined in Step 0
 
 - **Vendored coding-agent skill** (recommended — brings the five-sub-skill
   router and the byte-identical prompt parity guarantee; current **v2.0.0**):
-  - `npx --yes skills add DailybotHQ/ai-diff-reviewer@v2.0.0 --skill ai-diff-reviewer -y`
+  - `npx --yes skills add DailybotHQ/ai-diff-reviewer@v2.0.1 --skill ai-diff-reviewer -y`
     (**pinned to a published tag**; vendors into
     `.agents/skills/ai-diff-reviewer/` and records source + content hash in
     `skills-lock.json`; both `--yes` and `-y` are required — `--yes` covers

--- a/skills/deepworkplan/addons/ai-diff-reviewer/SPEC.md
+++ b/skills/deepworkplan/addons/ai-diff-reviewer/SPEC.md
@@ -143,7 +143,7 @@ acceptance — each reconciled if already present (§8):
 - The addon **MUST** install the vendored skill (the only supported install
   path) unless the developer recorded a declared exception (§2).
   Supported install method:
-  - `npx --yes skills add DailybotHQ/ai-diff-reviewer@v2.0.0 --skill ai-diff-reviewer -y`
+  - `npx --yes skills add DailybotHQ/ai-diff-reviewer@v2.0.1 --skill ai-diff-reviewer -y`
     (**tag-pinned**; both flags are required — `--yes` covers npm's own "Ok to
     proceed?" prompt; the subcommand `-y` covers the `skills` CLI's own "Which
     agents do you want to install to?" picker, which hangs in non-TTY without

--- a/skills/deepworkplan/addons/ai-diff-reviewer/templates/INTEGRATION.md
+++ b/skills/deepworkplan/addons/ai-diff-reviewer/templates/INTEGRATION.md
@@ -110,7 +110,7 @@ signalling ("Flow A / Flow B" phrases every subsequent request).
 
 ```bash
 # Tag-pinned install (pin whatever tag is current — this is the reproducible form)
-npx --yes skills add DailybotHQ/ai-diff-reviewer@v2.0.0 --skill ai-diff-reviewer -y
+npx --yes skills add DailybotHQ/ai-diff-reviewer@v2.0.1 --skill ai-diff-reviewer -y
 
 # Verify the vendored version matches the requested tag
 VENDORED=$(sed -nE 's/^version:[[:space:]]*"([^"]+)".*/\1/p' \

--- a/skills/deepworkplan/onboard/SKILL.md
+++ b/skills/deepworkplan/onboard/SKILL.md
@@ -136,7 +136,7 @@ mutates the target repository — non-destructively and by explicit design:
 - On the plan-driven path, plan artifacts under `.dwp/` as `create` defines.
 
 **Writes include:** with Phase 0 consent, Phase 7a may run the tag-pinned
-`npx --yes skills add DailybotHQ/ai-diff-reviewer@v2.0.0 --skill ai-diff-reviewer -y`
+`npx --yes skills add DailybotHQ/ai-diff-reviewer@v2.0.1 --skill ai-diff-reviewer -y`
 install into `.agents/skills/ai-diff-reviewer/` and bootstrap the repo-tailored
 `.review/extension.md`; decline or offline failure is recorded as a declared
 exception.

--- a/skills/deepworkplan/onboard/addons.md
+++ b/skills/deepworkplan/onboard/addons.md
@@ -20,7 +20,7 @@ and run its flow as a required step, under the Phase 0 onboarding consent:
    > `.github/ai-pr-reviewer/extension.md`), a `.review/.skip-bootstrap`
    marker, and any existing `pr-review.yml`. Fill gaps only.
 2. **Install the vendored skill, pinned:**
-   `npx --yes skills add DailybotHQ/ai-diff-reviewer@v2.0.0 --skill ai-diff-reviewer -y`
+   `npx --yes skills add DailybotHQ/ai-diff-reviewer@v2.0.1 --skill ai-diff-reviewer -y`
    (both `--yes` and `-y` are required in non-TTY; never an unpinned ref, never
    a remote installer piped to a shell). Assert the vendored `SKILL.md` version
    equals the requested tag.

--- a/skills/deepworkplan/spec/ADDONS.md
+++ b/skills/deepworkplan/spec/ADDONS.md
@@ -254,7 +254,7 @@ form**; only its CI surface is optional.
 
 - **Required local review (baseline since standard 2.3.0).** The `onboard` flow
   **MUST** install the vendored coding-agent skill
-  (`npx --yes skills add DailybotHQ/ai-diff-reviewer@v2.0.0 --skill ai-diff-reviewer -y`
+  (`npx --yes skills add DailybotHQ/ai-diff-reviewer@v2.0.1 --skill ai-diff-reviewer -y`
   — **tag-pinned**, both `--yes` and `-y` required) and bootstrap a
   repo-tailored extension file (`.review/extension.md`, via the upstream
   `generate-extension` sub-skill) as part of the baseline scaffolding

--- a/tests/agents-dogfood.bats
+++ b/tests/agents-dogfood.bats
@@ -101,3 +101,25 @@ setup() {
         grep -qE '^description:' "$skill"
     done
 }
+
+@test "the documented addon install pin matches the vendored addon version" {
+    # The release workflow refreshes `.agents/skills/ai-diff-reviewer/` to the
+    # latest upstream tag, but the install command the pack *teaches* is prose
+    # and is not rewritten with it. Those two drifted a patch apart once (the
+    # pack taught @v2.0.0 while the vendored copy was 2.0.1), which hands every
+    # adopter a stale reviewer. Make the invariant a CI gate instead of a habit.
+    #
+    # Only the exact pin is checked. `DailybotHQ/ai-diff-reviewer@v2` is the
+    # GitHub Action's floating major tag and is deliberately left floating so
+    # patch fixes flow automatically — it must NOT be pinned to a patch.
+    local vendored pins
+    vendored="$(grep -m1 '^version:' "$AGENTS_DIR/skills/ai-diff-reviewer/SKILL.md" \
+        | sed -E 's/.*"([^"]+)".*/\1/')"
+    [ -n "$vendored" ]
+
+    pins="$(grep -rhoE 'ai-diff-reviewer@v[0-9]+\.[0-9]+\.[0-9]+' "$REPO_ROOT/skills" \
+        | sed 's/.*@v//' | sort -u)"
+    [ -n "$pins" ]
+    # Every exact pin in the shipped pack names exactly the vendored version.
+    [ "$pins" = "$vendored" ]
+}


### PR DESCRIPTION
Follow-up to #38. This commit was pushed to the branch **after** #38 merged, so it missed the merge and is **not in `v4.0.1`**. Opening it from the same branch, which still carries it.

## The drift

Release dogfood refreshes the **vendored** addon under `.agents/skills/`, but it never rewrites the install command the shipped pack **teaches** — that lives in prose under `skills/deepworkplan/`. The two drifted apart:

| | version |
|---|---|
| Vendored `.agents/skills/ai-diff-reviewer/SKILL.md` | `2.0.1` |
| What six pack documents told adopters to install | `@v2.0.0` |

So every repository onboarded from this pack installed a **stale reviewer** — and the website's `/init.md`, which already says `v2.0.1`, was right where the skill itself was wrong.

All six exact pins repinned: `spec/ADDONS.md`, `onboard/SKILL.md`, `onboard/addons.md`, and the addon's `SKILL.md`, `SPEC.md`, `templates/INTEGRATION.md`.

The three `DailybotHQ/ai-diff-reviewer@v2` references are **deliberately untouched** — that is the GitHub Action's floating major tag, left floating so patch fixes flow automatically.

## Why a gate, not just a repin

A repin alone drifts again on the next upstream release. The invariant is now CI-enforced in `tests/agents-dogfood.bats`: every exact `ai-diff-reviewer@vX.Y.Z` pin under `skills/deepworkplan/` must equal the `version:` of the vendored addon.

I confirmed the gate **fails when drift is reintroduced**, not merely that it passes today:

```
not ok 12 the documented addon install pin matches the vendored addon version   # pin reverted to v2.0.0
ok 12 the documented addon install pin matches the vendored addon version       # restored
```

`AGENTS.md` documents the invariant, why release dogfood does not cover it, and the `grep -rn 'ai-diff-reviewer@v[0-9]' skills/` that finds every pin.

## Verification

**131/131 bats** (130 + the new gate) · shellcheck clean · frontmatter valid · `verify-integrity.sh` OK · dogfood re-synced byte-identical.

> Merging this cuts a patch release; the website then vendors that tag instead of `v4.0.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EXoNWro9Ds1Jc6ni3qRxNb