### PR TITLE
fix(onboard): stamp the standard the checker enforces, and resync the dogfood

### DIFF
--- a/.agents/skills/deepworkplan/SKILL.md
+++ b/.agents/skills/deepworkplan/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan
 description: DeepWorkPlan — turn any repo AI-first and run Deep Work Plans. Routes to create, execute, refine, resume, status, verify, and repo-onboarding sub-skills based on intent. Use when the developer wants to plan, execute, manage, or verify structured multi-task work, or make a repository AI-agent-ready.
-version: "4.0.1"
+version: "4.0.2"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write

--- a/.agents/skills/deepworkplan/addons/ai-diff-reviewer/SKILL.md
+++ b/.agents/skills/deepworkplan/addons/ai-diff-reviewer/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-addon-ai-diff-reviewer
 description: "DeepWorkPlan addon — required local review (baseline since standard 2.3.0), optional CI surface — connects an AI-first repo to the AI Diff Reviewer. Onboarding installs the vendored coding-agent skill and extension with consent; the Final Review runs the local pass when present or records a missing-reviewer finding without bootstrapping. Flow B CI setup remains an explicit opt-in delegated to upstream. Invocation errors never block, completed-review critical findings still follow the Final Review contract, and all install/auth/wizard details defer to upstream consent flows."
-version: "4.0.1"
+version: "4.0.2"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write

--- a/.agents/skills/deepworkplan/addons/dailybot/SKILL.md
+++ b/.agents/skills/deepworkplan/addons/dailybot/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-addon-dailybot
 description: Optional DeepWorkPlan addon that connects an AI-first repo to the developer's Dailybot team — installing (with consent) the Dailybot agent skill (DailybotHQ/agent-skill, currently 3.10.3) and/or the Dailybot CLI (DailybotHQ/cli, >= 3.7.0), wiring the plan lifecycle into best-effort agent updates - kickoff when a plan starts, significant task completions, a blocked report when an unattended run halts, and a milestone on plan completion - with payloads derived from the plan's state layer, and optionally committing the Dailybot skill's deterministic hook enforcement (dailybot hook lifecycle hooks) so the agent harness itself reminds agents about unreported work. Opt-in, never required, never blocks the work, reconciles existing setups instead of clobbering them, and defers all auth to the Dailybot skill's own consent flow. Use when the developer or team already uses Dailybot and wants DWP progress visible to humans.
-version: "4.0.1"
+version: "4.0.2"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write

--- a/.agents/skills/deepworkplan/addons/dependency-upgrade/SKILL.md
+++ b/.agents/skills/deepworkplan/addons/dependency-upgrade/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-addon-dependency-upgrade
 description: Optional DeepWorkPlan addon that safely upgrades a repo's dependencies — reasoning about the repo's ACTUAL package manager (npm/pnpm/yarn + ncu, pip/poetry/uv, cargo, go mod, bundler, composer, and more) rather than assuming npm — with a batched, validated, revertible workflow that detects the manager and manifests/lockfiles, classifies upgrades (patch/minor/major), upgrades in safe batches, runs the repo's real validation gate after each batch, reverts a failing batch, and summarizes. Opt-in, never required, reconciles with the repo's existing tooling. Use when the developer wants to bring dependencies up to date without breaking the build.
-version: "4.0.1"
+version: "4.0.2"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write

--- a/.agents/skills/deepworkplan/addons/design-system/SKILL.md
+++ b/.agents/skills/deepworkplan/addons/design-system/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-addon-design-system
 description: Optional DeepWorkPlan addon that gives a repo with a user-facing interface surface a DESIGN.md (under docs/, indexed from AGENTS.md) — a Markdown design-system file any coding agent reads to generate interface output consistent with the repo's OWN conventions. Covers three profiles detected independently from real files — visual-ui (rendered web/mobile/desktop UI), cli-output (styled terminal output — semantic colors, panels, spinners, prompts, TTY/NO_COLOR degradation), and conversational (chat/email messaging — voice and register, message anatomy, per-platform rendering). Reasons about the repo's ACTUAL design source (CSS custom properties, Tailwind config, token files, component styles, a CLI display/theme module, or message-composition helpers) rather than copying a brand file; checks contrast (WCAG AA), color-is-not-the-only-carrier, plain-text fallbacks, and token integrity. The visual-ui profile is default-on when detected (applied in trust mode, strongly recommended in guided mode); cli-output and conversational are recommended when detected and always asked about, never auto-applied. Never offered for a repo with no interface surface (pure library, headless service, infra-only); never required for baseline conformance; reconciles an existing DESIGN.md instead of clobbering it. Use when the developer wants agents to produce on-brand, consistent interface output — visual UI, terminal output, or outbound messages.
-version: "4.0.1"
+version: "4.0.2"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write

--- a/.agents/skills/deepworkplan/addons/devcontainer/SKILL.md
+++ b/.agents/skills/deepworkplan/addons/devcontainer/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-addon-devcontainer
 description: Optional DeepWorkPlan addon that adds (or reconciles) a compose-based devcontainer to a repo — base image and supporting services reasoned from the detected stack, with persistent AI-CLI auth, the dailybot-project-network, the DOCKER_DEV_ENV=vscode convention, and project-identity precedence. Opt-in, never required, reconciles existing setups instead of clobbering them. Use when the developer wants a reproducible isolated dev container for an AI-first repo.
-version: "4.0.1"
+version: "4.0.2"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write

--- a/.agents/skills/deepworkplan/author/SKILL.md
+++ b/.agents/skills/deepworkplan/author/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-author
 description: Author or update reusable skills, agents, and commands in the current repo — reason about the repo's .agents/ layout, follow the Open Agent Skills frontmatter contract, and keep the .agents/docs/ catalog in sync. Use when a developer wants to create or evolve the repo's agent kit (skills, agents, commands), or runs /skill-create or /agent-create.
-version: "4.0.1"
+version: "4.0.2"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write

--- a/.agents/skills/deepworkplan/create/SKILL.md
+++ b/.agents/skills/deepworkplan/create/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-create
 description: Create a Deep Work Plan for short or long work. Detect planning intent, materialize a compact Lite proposal first, then retain Lite or expand to Full task files when needed. Supports guided and trust handoff without executing product work.
-version: "4.0.1"
+version: "4.0.2"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write

--- a/.agents/skills/deepworkplan/execute/SKILL.md
+++ b/.agents/skills/deepworkplan/execute/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-execute
 description: Execute Lite or Full Deep Work Plans task-by-task — select validation from the actual surface, preserve state and evidence, recover safely, and finish with the Final Review.
-version: "4.0.1"
+version: "4.0.2"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write

--- a/.agents/skills/deepworkplan/onboard/SKILL.md
+++ b/.agents/skills/deepworkplan/onboard/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-onboard
 description: Make any repository AI-first — reason (never template) an adapted AGENTS.md, docs/, per-module docs and .agents/ kit from the real repo, discover and verify its full and scoped validation commands and source-to-test mapping, install the DeepWorkPlan skill, and, for a repository onboarded under an earlier version, perform a targeted, non-destructive, idempotent harness upgrade. Use when the developer wants to onboard or upgrade a repository for AI agents.
-version: "4.0.1"
+version: "4.0.2"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write
@@ -96,7 +96,7 @@ When this flow finishes, the target repo contains:
    escalation paths and fallback, plus the unit-first posture — so every future
    plan can select its gates instead of guessing (`../spec/DOCUMENTATION_STANDARD.md` §3.4).
 7. **A recorded standard and a first usable outcome** — the provenance line
-   `DWP standard: 2.3.0 (onboarded YYYY-MM-DD; skill x.y.z)` in `AGENTS.md`, and
+   `DWP standard: 2.4.0 (onboarded YYYY-MM-DD; skill x.y.z)` in `AGENTS.md`, and
    a `.dwp/onboard/REPORT.md` that names the verified command and mapping, the
    installed skill identity and version, the active capability limits (what
    could not be verified and why), and the next useful action.
@@ -162,7 +162,7 @@ Phase 0 consent; a decline is recorded as a declared exception).
    - **Existing and previously onboarded → harness upgrade.** `AGENTS.md`
      and/or `.agents/` already exist **and** the repository's guidance predates
      the installed skill's requirements: no `DWP standard:` provenance line, a
-     provenance line older than the standard this skill implements (2.3.0), or a
+     provenance line older than the standard this skill implements (2.4.0), or a
      `docs/TESTING_GUIDE.md` without the scoped-invocation / mapping / posture
      content of `../spec/DOCUMENTATION_STANDARD.md` §3.4. In this case run the
      **targeted upgrade** (§3.5) instead of a full re-onboarding: recon only what
@@ -426,7 +426,7 @@ context. It MUST serve three roles:
    (`full` / `scoped`). **Mark** any command that
    runs only in CI or only inside a container (e.g. "must run **inside** the
    Docker container"), and any scoped pattern that is proposed/unverified.
-4. **Provenance** — one line, `DWP standard: 2.3.0 (onboarded YYYY-MM-DD;
+4. **Provenance** — one line, `DWP standard: 2.4.0 (onboarded YYYY-MM-DD;
    skill x.y.z)` (on upgrade: `…; upgraded YYYY-MM-DD; skill x.y.z`), so a
    checker and a future agent can tell which standard the repository declares
    (`../spec/DOCUMENTATION_STANDARD.md` §3.5).

--- a/.agents/skills/deepworkplan/refine/SKILL.md
+++ b/.agents/skills/deepworkplan/refine/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-refine
 description: Refine a Deep Work Plan — safely edit scope, add, split or reorder tasks, promote a Lite plan to Full task files, recover a partial promotion, or explicitly migrate a legacy plan, always preserving completed evidence.
-version: "4.0.1"
+version: "4.0.2"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write

--- a/.agents/skills/deepworkplan/resume/SKILL.md
+++ b/.agents/skills/deepworkplan/resume/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-resume
 description: Resume interrupted Lite or Full Deep Work Plans from durable Markdown and state, including safe recovery of promotions without duplicating completed work or gates.
-version: "4.0.1"
+version: "4.0.2"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write

--- a/.agents/skills/deepworkplan/spec/DOCUMENTATION_STANDARD.md
+++ b/.agents/skills/deepworkplan/spec/DOCUMENTATION_STANDARD.md
@@ -333,9 +333,16 @@ the onboarding flow **MUST** keep them distinct:
   report, per file, what it added or changed.
 - **Recorded provenance.** A repository that adopts this standard **SHOULD**
   record it — a line such as
-  `DWP standard: 2.3.0 (onboarded YYYY-MM-DD; upgraded YYYY-MM-DD; skill x.y.z)`
+  `DWP standard: 2.4.0 (onboarded YYYY-MM-DD; upgraded YYYY-MM-DD; skill x.y.z)`
   in `AGENTS.md` or `docs/README.md` — so a checker and a future agent can tell
   which standard the repository declares.
+
+  The version in that line is the **umbrella DWP standard** — the `Version` of
+  `DWP_SPECIFICATION.md` — not the version of this document or of any other
+  single spec document. Each spec document carries its own version and they
+  advance independently, so recording one of those would compare unrelated
+  scales: a conformance checker reads this line against the DWP standard it
+  implements and rejects a repository declaring one it does not support.
 - **Legacy versus declared.** A conformance checker **MUST** distinguish a
   repository onboarded under an earlier version (no §3.4 content, no declaration)
   from a repository that declares this version and lacks a **MUST**: the former

--- a/.agents/skills/deepworkplan/status/SKILL.md
+++ b/.agents/skills/deepworkplan/status/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-status
 description: Report Lite or Full Deep Work Plan status — format, approval, readiness, progress, checkpoint, blockers and Markdown/state consistency — without modifying anything.
-version: "4.0.1"
+version: "4.0.2"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob

--- a/.agents/skills/deepworkplan/verify/SKILL.md
+++ b/.agents/skills/deepworkplan/verify/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-verify
 description: Verify that a repository is DeepWorkPlan-conformant (AI-first) and that its plans are well-formed, producing an objective pass/fail report. Use when the developer asks to verify, audit, or check conformance of a repo or a plan.
-version: "4.0.1"
+version: "4.0.2"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -17,7 +17,7 @@
       "source": "DailybotHQ/deepworkplan-skill",
       "sourceType": "github",
       "skillPath": "skills/deepworkplan/SKILL.md",
-      "computedHash": "a29ee6054373abdedaa641dab6826e75bdf6b04b50e483a5222cd786cd9b88ee"
+      "computedHash": "be4e47eb606e48a390f8b472c609743572ab7fe5df8cc566e8e1094ea35ac0e9"
     }
   }
 }

--- a/skills/deepworkplan/onboard/SKILL.md
+++ b/skills/deepworkplan/onboard/SKILL.md
@@ -96,7 +96,7 @@ When this flow finishes, the target repo contains:
    escalation paths and fallback, plus the unit-first posture — so every future
    plan can select its gates instead of guessing (`../spec/DOCUMENTATION_STANDARD.md` §3.4).
 7. **A recorded standard and a first usable outcome** — the provenance line
-   `DWP standard: 2.3.0 (onboarded YYYY-MM-DD; skill x.y.z)` in `AGENTS.md`, and
+   `DWP standard: 2.4.0 (onboarded YYYY-MM-DD; skill x.y.z)` in `AGENTS.md`, and
    a `.dwp/onboard/REPORT.md` that names the verified command and mapping, the
    installed skill identity and version, the active capability limits (what
    could not be verified and why), and the next useful action.
@@ -162,7 +162,7 @@ Phase 0 consent; a decline is recorded as a declared exception).
    - **Existing and previously onboarded → harness upgrade.** `AGENTS.md`
      and/or `.agents/` already exist **and** the repository's guidance predates
      the installed skill's requirements: no `DWP standard:` provenance line, a
-     provenance line older than the standard this skill implements (2.3.0), or a
+     provenance line older than the standard this skill implements (2.4.0), or a
      `docs/TESTING_GUIDE.md` without the scoped-invocation / mapping / posture
      content of `../spec/DOCUMENTATION_STANDARD.md` §3.4. In this case run the
      **targeted upgrade** (§3.5) instead of a full re-onboarding: recon only what
@@ -426,7 +426,7 @@ context. It MUST serve three roles:
    (`full` / `scoped`). **Mark** any command that
    runs only in CI or only inside a container (e.g. "must run **inside** the
    Docker container"), and any scoped pattern that is proposed/unverified.
-4. **Provenance** — one line, `DWP standard: 2.3.0 (onboarded YYYY-MM-DD;
+4. **Provenance** — one line, `DWP standard: 2.4.0 (onboarded YYYY-MM-DD;
    skill x.y.z)` (on upgrade: `…; upgraded YYYY-MM-DD; skill x.y.z`), so a
    checker and a future agent can tell which standard the repository declares
    (`../spec/DOCUMENTATION_STANDARD.md` §3.5).

--- a/skills/deepworkplan/spec/DOCUMENTATION_STANDARD.md
+++ b/skills/deepworkplan/spec/DOCUMENTATION_STANDARD.md
@@ -333,9 +333,16 @@ the onboarding flow **MUST** keep them distinct:
   report, per file, what it added or changed.
 - **Recorded provenance.** A repository that adopts this standard **SHOULD**
   record it — a line such as
-  `DWP standard: 2.3.0 (onboarded YYYY-MM-DD; upgraded YYYY-MM-DD; skill x.y.z)`
+  `DWP standard: 2.4.0 (onboarded YYYY-MM-DD; upgraded YYYY-MM-DD; skill x.y.z)`
   in `AGENTS.md` or `docs/README.md` — so a checker and a future agent can tell
   which standard the repository declares.
+
+  The version in that line is the **umbrella DWP standard** — the `Version` of
+  `DWP_SPECIFICATION.md` — not the version of this document or of any other
+  single spec document. Each spec document carries its own version and they
+  advance independently, so recording one of those would compare unrelated
+  scales: a conformance checker reads this line against the DWP standard it
+  implements and rejects a repository declaring one it does not support.
 - **Legacy versus declared.** A conformance checker **MUST** distinguish a
   repository onboarded under an earlier version (no §3.4 content, no declaration)
   from a repository that declares this version and lacks a **MUST**: the former

--- a/tests/agents-dogfood.bats
+++ b/tests/agents-dogfood.bats
@@ -123,3 +123,28 @@ setup() {
     # Every exact pin in the shipped pack names exactly the vendored version.
     [ "$pins" = "$vendored" ]
 }
+
+@test "the provenance version onboard writes matches the standard the checker enforces" {
+    # `DWP standard: X` is stamped into every onboarded repo by `onboard` and
+    # read back by `conformance.sh`, which compares it against SUPPORTED_SPEC —
+    # the DWP_SPECIFICATION version. Those drifted once: onboard wrote 2.3.0
+    # (the DOCUMENTATION_STANDARD version) while the checker enforced 2.4.0, so
+    # every freshly onboarded repo declared a standard older than the one it had
+    # just received. Spec documents version independently, so the three sources
+    # have to be pinned together deliberately.
+    local pack spec supported written
+    pack="$REPO_ROOT/skills/deepworkplan"
+
+    spec="$(grep -m1 -E '^\| \*\*Version\*\* \|' "$pack/spec/DWP_SPECIFICATION.md" \
+        | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')"
+    supported="$(grep -m1 -E '^SUPPORTED_SPEC=' "$pack/verify/conformance.sh" \
+        | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')"
+    [ -n "$spec" ]
+    [ "$supported" = "$spec" ]
+
+    # Every documented `DWP standard: X` example names that same version.
+    written="$(grep -rhoE 'DWP standard: [0-9]+\.[0-9]+\.[0-9]+' "$pack" \
+        | sed 's/.*: //' | sort -u)"
+    [ -n "$written" ]
+    [ "$written" = "$spec" ]
+}


### PR DESCRIPTION
## Two version scales were being compared as one

`onboard` stamps `DWP standard: X` into **every repository it touches**. `conformance.sh` reads that line back and compares it against `SUPPORTED_SPEC` — the `DWP_SPECIFICATION.md` version, currently **2.4.0**.

`onboard` was writing **2.3.0** — the version of `DOCUMENTATION_STANDARD.md`.

| Source | Version |
|---|---|
| `DWP_SPECIFICATION.md` (what the checker enforces) | 2.4.0 |
| `DOCUMENTATION_STANDARD.md` (what onboard was writing) | 2.3.0 |
| `ADDONS.md` | 2.1.0 |

Each spec document versions independently — `ADDONS.md` is already on a third number. Comparing one scale against another is only accidentally safe while the numbers happen to sit close.

The effect was already visible: **every repository onboarded with this pack declared a standard one minor older than the one it had just received**, while the site publishes 2.4.0 as the current repository-facing standard.

### The upgrade threshold carried the same literal

Phase 0 selects the targeted harness upgrade for a repo whose provenance line is *"older than the standard this skill implements (2.3.0)"*. A repo sitting at 2.3.0 was therefore considered current and would **never auto-select the upgrade**, even after the standard moved past it. That is precisely the case that matters when rolling this out across repositories that were onboarded earlier.

## The fix

Settled on the **umbrella standard** — the `DWP_SPECIFICATION.md` version — because that is what the checker compares against and what the published site means by "the current repository-facing standard".

`DOCUMENTATION_STANDARD.md` §3.5 now states which version belongs in the line instead of leaving it to inference. The old wording — *"a repository that adopts **this** standard SHOULD record it"*, in a document carrying its own version — is exactly what invited the mistake.

## Pinned with a CI gate

`DWP_SPECIFICATION`'s version, `conformance.sh`'s `SUPPORTED_SPEC`, and every documented `DWP standard: X` example must now agree. Confirmed it **fails when the old value is put back**, not merely that it passes today:

```
not ok 13 the provenance version onboard writes matches the standard the checker enforces   # restored 2.3.0
ok 13 the provenance version onboard writes matches the standard the checker enforces       # fixed
```

## Also: dogfood resync

The 4.0.1 and 4.0.2 releases each bumped `skills/deepworkplan/**` while auto-release deliberately leaves `.agents/skills/deepworkplan/` alone, so the mirror had fallen a patch behind again. Resynced to 4.0.2 (byte-identical, lock hash updated).

## Verification

**132/132 bats** (131 + the new gate) · shellcheck clean · frontmatter valid · `verify-integrity.sh` OK.

Existing fixtures that write `DWP standard: 2.3.0` into a test `AGENTS.md` are untouched on purpose — they represent repositories onboarded under the older standard, which is exactly the case the checker must keep accepting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EXoNWro9Ds1Jc6ni3qRxNb