### PR TITLE
v5 phase 2: live-validation fixes, seven-command kit, plan-state format decision (ADR 0002)

### DIFF
--- a/.agents/skills/deepworkplan/SKILL.md
+++ b/.agents/skills/deepworkplan/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan
 description: DeepWorkPlan — turn any repo AI-first and run Deep Work Plans. Routes to create, execute, refine, resume, status, verify, upgrade, and repo-onboarding sub-skills based on intent. Use when the developer wants to plan, execute, manage, or verify structured multi-task work, or make a repository AI-agent-ready.
-version: "4.0.3"
+version: "5.0.0"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write

--- a/.agents/skills/deepworkplan/addons/ai-diff-reviewer/SKILL.md
+++ b/.agents/skills/deepworkplan/addons/ai-diff-reviewer/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-addon-ai-diff-reviewer
 description: "DeepWorkPlan addon — required local review (baseline since standard 2.3.0), optional CI surface — connects an AI-first repo to the AI Diff Reviewer. Onboarding installs the vendored coding-agent skill and extension with consent; the Final Review runs the local pass when present or records a missing-reviewer finding without bootstrapping. Flow B CI setup remains an explicit opt-in delegated to upstream. Invocation errors never block, completed-review critical findings still follow the Final Review contract, and all install/auth/wizard details defer to upstream consent flows."
-version: "4.0.3"
+version: "5.0.0"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write

--- a/.agents/skills/deepworkplan/addons/dailybot/SKILL.md
+++ b/.agents/skills/deepworkplan/addons/dailybot/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-addon-dailybot
 description: Optional DeepWorkPlan addon that connects an AI-first repo to the developer's Dailybot team — installing (with consent) the Dailybot agent skill (DailybotHQ/agent-skill, currently 3.10.3) and/or the Dailybot CLI (DailybotHQ/cli, >= 3.7.0), wiring the plan lifecycle into best-effort agent updates - kickoff when a plan starts, significant task completions, a blocked report when an unattended run halts, and a milestone on plan completion - with payloads derived from the plan's state layer, and optionally committing the Dailybot skill's deterministic hook enforcement (dailybot hook lifecycle hooks) so the agent harness itself reminds agents about unreported work. Opt-in, never required, never blocks the work, reconciles existing setups instead of clobbering them, and defers all auth to the Dailybot skill's own consent flow. Use when the developer or team already uses Dailybot and wants DWP progress visible to humans.
-version: "4.0.3"
+version: "5.0.0"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write

--- a/.agents/skills/deepworkplan/addons/dependency-upgrade/SKILL.md
+++ b/.agents/skills/deepworkplan/addons/dependency-upgrade/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-addon-dependency-upgrade
 description: DeepWorkPlan addon that safely upgrades a repo's dependencies — reasoning about the repo's ACTUAL package manager (npm/pnpm/yarn + ncu, pip/poetry/uv, cargo, go mod, bundler, composer, and more) rather than assuming npm — with a batched, validated, revertible workflow that detects the manager and manifests/lockfiles, classifies upgrades (patch/minor/major), upgrades in safe batches, runs the repo's real validation gate after each batch, reverts a failing batch, and summarizes. Near-default — offered for every repo with declared dependencies, and its delegator installs under the onboarding consent unless declined; upgrades themselves never run automatically, only as explicit, gated work. Never required for baseline conformance; reconciles with the repo's existing tooling. Use when the developer wants to bring dependencies up to date without breaking the build.
-version: "4.0.3"
+version: "5.0.0"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write

--- a/.agents/skills/deepworkplan/addons/design-system/SKILL.md
+++ b/.agents/skills/deepworkplan/addons/design-system/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-addon-design-system
 description: Optional DeepWorkPlan addon that gives a repo with a user-facing interface surface a DESIGN.md (under docs/, indexed from AGENTS.md) — a Markdown design-system file any coding agent reads to generate interface output consistent with the repo's OWN conventions. Covers three profiles detected independently from real files — visual-ui (rendered web/mobile/desktop UI), cli-output (styled terminal output — semantic colors, panels, spinners, prompts, TTY/NO_COLOR degradation), and conversational (chat/email messaging — voice and register, message anatomy, per-platform rendering). Reasons about the repo's ACTUAL design source (CSS custom properties, Tailwind config, token files, component styles, a CLI display/theme module, or message-composition helpers) rather than copying a brand file; checks contrast (WCAG AA), color-is-not-the-only-carrier, plain-text fallbacks, and token integrity. A detected interface surface makes the evaluation and offer mandatory (with a clear recommendation), while installation always requires explicit acceptance — no profile is auto-applied, even in trust mode. Never offered for a repo with no interface surface (pure library, headless service, infra-only); never required for baseline conformance; reconciles an existing DESIGN.md instead of clobbering it. Use when the developer wants agents to produce on-brand, consistent interface output — visual UI, terminal output, or outbound messages.
-version: "4.0.3"
+version: "5.0.0"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write

--- a/.agents/skills/deepworkplan/addons/devcontainer/SKILL.md
+++ b/.agents/skills/deepworkplan/addons/devcontainer/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-addon-devcontainer
 description: Optional DeepWorkPlan addon that adds (or reconciles) a compose-based devcontainer to a repo — base image and supporting services reasoned from the detected stack, with persistent AI-CLI auth, the dailybot-project-network, the DOCKER_DEV_ENV=vscode convention, and project-identity precedence. Opt-in, never required, reconciles existing setups instead of clobbering them. Use when the developer wants a reproducible isolated dev container for an AI-first repo.
-version: "4.0.3"
+version: "5.0.0"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write

--- a/.agents/skills/deepworkplan/author/SKILL.md
+++ b/.agents/skills/deepworkplan/author/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-author
 description: Author or update reusable skills, agents, and commands in the current repo — reason about the repo's .agents/ layout, follow the Open Agent Skills frontmatter contract, and keep the .agents/docs/ catalog in sync. Use when a developer wants to create or evolve the repo's agent kit (skills, agents, commands), or runs /skill-create or /agent-create.
-version: "4.0.3"
+version: "5.0.0"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write

--- a/.agents/skills/deepworkplan/create/SKILL.md
+++ b/.agents/skills/deepworkplan/create/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-create
 description: Create a Deep Work Plan for short or long work. Detect planning intent, materialize a compact Lite proposal first, then retain Lite or expand to Full task files when needed. Supports guided and trust handoff without executing product work.
-version: "4.0.3"
+version: "5.0.0"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write
@@ -387,7 +387,8 @@ One concise record here; machine state is derived from it, never duplicated.
 ## 7. Plan Status / Notes    → `Plan Status: 0/N completed`
 
 ## Task 1 {#task-1}
-**Goal** · **Touched Surface** (planned surface, risk class, test mapping,
+**Goal** · **Context** (what a fresh session needs to start this task alone) ·
+**Touched Surface** (planned surface, risk class, test mapping,
 selected gate and why) · **Acceptance Criteria** · **Validation** (a runnable
 command) · **Completion log** (status, skills disposition, gate record).
 
@@ -595,8 +596,8 @@ and the Final Review is always sequential.
 - Task IDs are contiguous `1..N`; each `{#task-N}` anchor occurs exactly once;
   every Task List link resolves to its anchor; the Final Review is task `N` and
   the only final task.
-- Every task record has a Goal, a Touched Surface, Acceptance Criteria, a
-  runnable Validation gate and a completion-log placeholder. No task was padded
+- Every task record has a Goal, a Context, a Touched Surface, Acceptance
+  Criteria, a runnable Validation gate and a completion-log placeholder. No task was padded
   in to reach a count.
 - `manifest.json` validates against the v2 manifest schema with
   `plan_format: "lite"`; `state.json` validates against the v2 state schema, its

--- a/.agents/skills/deepworkplan/execute/SKILL.md
+++ b/.agents/skills/deepworkplan/execute/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-execute
 description: Execute Lite or Full Deep Work Plans task-by-task — select validation from the actual surface, preserve state and evidence, recover safely, and finish with the Final Review.
-version: "4.0.3"
+version: "5.0.0"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write
@@ -304,6 +304,14 @@ Rules (strict):
    above, and no other field is accepted; the state schemas reject anything
    else, so a plan whose gates carry an invented field fails verification even
    though its work is done (`../spec/PLAN_STATE.md` §4.2).
+
+   Prefer the shipped updater for this close step — it applies exactly the
+   delta above (status, gates, outcome, commit, counts, checkpoint) atomically
+   and its output is closed-schema-valid where the input was:
+   `python3 ../shared/update-state.py <plan>/state.json --task N --status completed --commit <hash> --gate '<command>|<exit>|<evidence>' --worked '<one line>'`.
+   A whole-file rewrite of `state.json` remains the documented fallback when
+   scripting is genuinely unavailable; reconciliation from markdown (§5) is
+   always a whole-file regeneration.
 
 7. **Dailybot per-task report (only for individually significant tasks)** — after
    committing a task that is independently significant (feature, bug fix, major

--- a/.agents/skills/deepworkplan/onboard/SKILL.md
+++ b/.agents/skills/deepworkplan/onboard/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-onboard
 description: Make any repository AI-first — reason (never template) an adapted AGENTS.md, docs/, per-module docs and .agents/ kit from the real repo, discover and verify its full and scoped validation commands and source-to-test mapping, install the DeepWorkPlan skill, and, for a repository onboarded under an earlier version, perform a targeted, non-destructive, idempotent harness upgrade. Use when the developer wants to onboard or upgrade a repository for AI agents.
-version: "4.0.3"
+version: "5.0.0"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write
@@ -565,8 +565,9 @@ and **stack-appropriate**, not generic boilerplate.
   `security-auditor`, plus any **stack-specific** role the preset suggests
   (e.g. a Django `migration-author`, a Vue `component-author`). Each persona
   must be described well enough that a non-Claude agent can read it.
-- **`.agents/commands/`** — the six short DWP commands (`dwp-create`,
-  `dwp-execute`, `dwp-refine`, `dwp-resume`, `dwp-status`, `dwp-verify`) plus stack-relevant
+- **`.agents/commands/`** — the seven short DWP commands (`dwp-create`,
+  `dwp-execute`, `dwp-refine`, `dwp-resume`, `dwp-status`, `dwp-verify`,
+  `dwp-upgrade`) plus stack-relevant
   ones (`code-review`, `pr`, `commit`, `branch`). **The `dwp-*` commands MUST be
   thin delegators, NOT copies of the flow.** Each is a short file (frontmatter
   `description:` + a body) that routes the invocation to the matching sub-skill
@@ -598,6 +599,9 @@ and **stack-appropriate**, not generic boilerplate.
 > **Existing-repo note:** if `.agents/` (or per-tool `.claude/` / `.cursor/`)
 > config already exists, reconcile into `.agents/` and add the `.claude` and
 > `.cursor` symlinks only if absent; never delete existing personas/commands without asking.
+> A tool-created `.claude/` / `.cursor/` directory whose only content is symlinks
+> into `.agents/` may be converted to the canonical root symlink outright — that
+> is a zero-loss reconciliation, not a deletion.
 > On a **harness upgrade** (Phase 0), refresh the `dwp-*`, `skill-create` and
 > `agent-create` delegators from `command-templates/` (they are thin and owned
 > by the skill), leave every other command, agent and skill as-is, and update
@@ -696,9 +700,9 @@ done.
 5. **`.agents/`** has `agents/`, `commands/`, `skills/`, `docs/`, `settings.json`
    and `.claude → .agents` + `.cursor → .agents` symlinks (or documented fallback);
    `skills_agents_catalog.md` and `COMMANDS_REFERENCE.md` **match** what was
-   actually created (no phantom entries). **The six `dwp-*` commands exist** in
+   actually created (no phantom entries). **The seven `dwp-*` commands exist** in
    `.agents/commands/` (`dwp-create`, `dwp-execute`, `dwp-refine`, `dwp-resume`,
-   `dwp-status`, `dwp-verify`) and are thin delegators (no leftover `<skill-path>`
+   `dwp-status`, `dwp-verify`, `dwp-upgrade`) and are thin delegators (no leftover `<skill-path>`
    placeholder, no copied flow body).
 6. **DeepWorkPlan skill is discoverable** and `.dwp/` exists, is gitignored
    (`git check-ignore .dwp` confirms), and has `plans/`. **`tmp/`

--- a/.agents/skills/deepworkplan/onboard/command-templates/dwp-upgrade.md
+++ b/.agents/skills/deepworkplan/onboard/command-templates/dwp-upgrade.md
@@ -1,0 +1,19 @@
+---
+description: Check for a newer DeepWorkPlan skill and upgrade only with explicit consent (provided by the installed `deepworkplan` skill)
+---
+
+# /dwp-upgrade — provided by the `deepworkplan` skill
+
+> Thin alias. The flow lives in the installed `deepworkplan` skill — this file
+> only routes to it, so there is a single source of truth and no drift.
+
+## What to do
+
+Route this invocation to the **upgrade** sub-skill of the installed `deepworkplan`
+skill and follow it: read `<skill-path>/deepworkplan/upgrade/SKILL.md` and execute
+its flow. The check phase is **read-only**; nothing installs without your explicit
+acceptance, and `.dwp/` plan history is never migrated by an upgrade.
+
+> Other agents: invoke the skill's `deepworkplan-upgrade` sub-skill directly
+> (`/deepworkplan-upgrade` in Claude Code, `#deepworkplan-upgrade` elsewhere).
+> This `dwp-upgrade` file is the shorter, conventional alias.

--- a/.agents/skills/deepworkplan/onboard/command-templates/dwp-verify.md
+++ b/.agents/skills/deepworkplan/onboard/command-templates/dwp-verify.md
@@ -1,0 +1,19 @@
+---
+description: Verify repo/plan conformance against the DWP spec (read-only) (provided by the installed `deepworkplan` skill)
+---
+
+# /dwp-verify — provided by the `deepworkplan` skill
+
+> Thin alias. The flow lives in the installed `deepworkplan` skill — this file
+> only routes to it, so there is a single source of truth and no drift.
+
+## What to do
+
+Route this invocation to the **verify** sub-skill of the installed `deepworkplan`
+skill and follow it: read `<skill-path>/deepworkplan/verify/SKILL.md` and execute
+its flow. This is a **read-only** conformance check (repo onboarding state or a
+plan against the spec) — it reports findings and never mutates files.
+
+> Other agents: invoke the skill's `deepworkplan-verify` sub-skill directly
+> (`/deepworkplan-verify` in Claude Code, `#deepworkplan-verify` elsewhere). This
+> `dwp-verify` file is the shorter, conventional alias.

--- a/.agents/skills/deepworkplan/refine/SKILL.md
+++ b/.agents/skills/deepworkplan/refine/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-refine
 description: Refine a Deep Work Plan — safely edit scope, add, split or reorder tasks, promote a Lite plan to Full task files, recover a partial promotion, or explicitly migrate a legacy plan, always preserving completed evidence.
-version: "4.0.3"
+version: "5.0.0"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write

--- a/.agents/skills/deepworkplan/resume/SKILL.md
+++ b/.agents/skills/deepworkplan/resume/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-resume
 description: Resume interrupted Lite or Full Deep Work Plans from durable Markdown and state, including safe recovery of promotions without duplicating completed work or gates.
-version: "4.0.3"
+version: "5.0.0"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write
@@ -143,7 +143,10 @@ pointer**, never by replaying everything.
    | mid-implementation with no checkpoint note | dirty tree only | review the diff against the task; incorporate valid partial progress, finish the rest |
 
    Changed inputs since a recorded gate (a later edit, a `refine`, a new
-   revision) invalidate that gate → rerun it.
+   revision) invalidate that gate → rerun it. Where the table resumes the
+   tail of the update order, the `state.json` step may use the shipped
+   updater (`../shared/update-state.py`) as a targeted, atomic mutation;
+   only the reconcile-from-markdown row regenerates the whole file.
 6. **Takeover from another agent or model.** If the checkpoint, log or
    `PROGRESS.md` was written by a different agent/model (`state.json.updated_by`,
    the log's wording) or the session is a fresh context: read the checkpoint

--- a/.agents/skills/deepworkplan/shared/update-state.py
+++ b/.agents/skills/deepworkplan/shared/update-state.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Apply a targeted mutation to a Deep Work Plan state.json (v2 schema).
+
+The state layer stays JSON (ADR 0002); this helper exists so an executing
+agent applies a task-close or status change as a bounded delta — set one
+task's status, attach its gate records and outcome, recompute counts and the
+checkpoint — instead of re-emitting the whole file from context. It writes
+atomically (temp file + rename) and only ever assigns fields the closed v2
+schema knows, so its output validates where the input did.
+
+Stdlib only (Python 3.9+). It mutates exactly one file: the state.json given
+as the first argument. Whole-file regeneration (create, refine recount,
+markdown-wins reconciliation) stays a manual, documented operation.
+
+Usage:
+  update-state.py STATE.json --task N --status completed \
+      [--gate "command|exit_code|evidence"] [--gate ...] \
+      [--worked "one line"] [--notes "pointer"] [--commit <sha>] \
+      [--checkpoint-step "step"] [--checkpoint-note "note"] \
+      [--agent <name>] [--model <name>]
+
+Exit codes: 0 applied · 1 validation error (nothing written) · 2 usage.
+"""
+import argparse
+import datetime
+import json
+import os
+import re
+import sys
+import tempfile
+
+TASK_STATUSES = ("pending", "in_progress", "completed", "blocked", "skipped")
+PLAN_STATUSES = ("pending", "in_progress", "completed", "blocked")
+COMMIT_RE = re.compile(r"^[0-9a-f]{7,40}$")
+# Closed-schema field budgets (plan-state-v2.schema.json) enforced on write.
+LIMITS = {
+    "gate.command": 500, "gate.evidence": 500,
+    "outcome.worked": 500, "outcome.notes": 1000,
+    "checkpoint.step": 200, "checkpoint.note": 500,
+    "updated_by.agent": 100, "updated_by.model": 100,
+}
+
+
+def die(msg, code=1):
+    print(f"update-state: {msg}", file=sys.stderr)
+    sys.exit(code)
+
+
+def now():
+    return datetime.datetime.now(datetime.timezone.utc).isoformat()
+
+
+def parse_gates(raw):
+    """Each --gate is 'command|exit_code|evidence'."""
+    gates = []
+    for spec in raw:
+        parts = spec.split("|", 2)
+        if len(parts) != 3:
+            die(f"--gate expects 'command|exit_code|evidence', got: {spec!r}")
+        command, exit_code, evidence = (p.strip() for p in parts)
+        try:
+            code = int(exit_code)
+        except ValueError:
+            die(f"--gate exit_code is not an integer: {exit_code!r}")
+        if len(command) > LIMITS["gate.command"]:
+            die(f"gate command exceeds {LIMITS['gate.command']} chars")
+        if len(evidence) > LIMITS["gate.evidence"]:
+            die(f"gate evidence exceeds {LIMITS['gate.evidence']} chars")
+        gates.append({"command": command, "passes": code == 0,
+                      "last_run": now(), "exit_code": code,
+                      "evidence": evidence})
+    return gates
+
+
+def derive_plan_status(state):
+    tasks = state["tasks"]
+    if all(t["status"] in ("completed", "skipped") for t in tasks):
+        return "completed"
+    if any(t["status"] == "in_progress" for t in tasks):
+        return "in_progress"
+    if state["completed_count"] > 0:
+        return "in_progress"
+    return "pending"
+
+
+def next_checkpoint(state, task_id, step, note):
+    pending = [t["id"] for t in state["tasks"]
+               if t["status"] not in ("completed", "skipped")]
+    if pending:
+        target = min(pending)
+        step = step or "start"
+        note = note or f"Task {task_id} closed. Next: Task {target}."
+    else:
+        target = task_id
+        step = step or "done"
+        note = note or "Plan completed."
+    if len(step) > LIMITS["checkpoint.step"]:
+        die(f"checkpoint step exceeds {LIMITS['checkpoint.step']} chars")
+    if len(note) > LIMITS["checkpoint.note"]:
+        die(f"checkpoint note exceeds {LIMITS['checkpoint.note']} chars")
+    return {"task": target, "step": step, "at": now(), "note": note}
+
+
+def main():
+    ap = argparse.ArgumentParser(add_help=True, description=__doc__.splitlines()[0])
+    ap.add_argument("state", help="path to the plan's state.json")
+    ap.add_argument("--task", type=int, required=True, metavar="N")
+    ap.add_argument("--status", required=True, choices=TASK_STATUSES)
+    ap.add_argument("--gate", action="append", default=[], metavar="CMD|EXIT|EVIDENCE")
+    ap.add_argument("--worked", default="")
+    ap.add_argument("--notes", default="")
+    ap.add_argument("--commit", default="")
+    ap.add_argument("--checkpoint-step", default="")
+    ap.add_argument("--checkpoint-note", default="")
+    ap.add_argument("--agent", default="")
+    ap.add_argument("--model", default="")
+    args = ap.parse_args()
+
+    for field, value in (("outcome.worked", args.worked), ("outcome.notes", args.notes)):
+        if len(value) > LIMITS[field]:
+            die(f"--{field.split('.')[1]} exceeds {LIMITS[field]} chars")
+    if args.commit and not COMMIT_RE.match(args.commit):
+        die(f"--commit is not a commit hash: {args.commit!r}")
+    if args.state not in ("", ) and not os.path.isfile(args.state):
+        die(f"state file not found: {args.state}")
+
+    try:
+        with open(args.state, encoding="utf-8") as fh:
+            state = json.load(fh)
+    except (OSError, json.JSONDecodeError) as exc:
+        die(f"cannot read state: {exc}")
+
+    tasks = state.get("tasks") or []
+    task = next((t for t in tasks if t.get("id") == args.task), None)
+    if task is None:
+        die(f"no task {args.task} in this plan "
+            f"(have: {[t.get('id') for t in tasks]})")
+
+    stamp = now()
+    if task["status"] != args.status:
+        # Idempotence: timestamps record when a transition happened, so a
+        # replayed invocation keeps the original reading.
+        if args.status in ("in_progress", "completed", "blocked") and not task.get("started_at"):
+            task["started_at"] = stamp
+        if args.status == "completed" and not task.get("completed_at"):
+            task["completed_at"] = stamp
+    task["status"] = args.status
+    if args.commit:
+        task["commit"] = args.commit
+    if args.worked or args.notes:
+        outcome = dict(task.get("outcome") or {})
+        if args.worked:
+            outcome["worked"] = args.worked
+        if args.notes:
+            outcome["notes"] = args.notes
+        task["outcome"] = outcome
+    if args.gate:
+        task["gates"] = parse_gates(args.gate)
+
+    state["completed_count"] = sum(1 for t in tasks if t["status"] == "completed")
+    # Plan-level `blocked` carries its own record (reason/since) authored by
+    # the blocked protocol; this helper never guesses it.
+    state["status"] = derive_plan_status(state)
+    state["updated_at"] = stamp
+    state["checkpoint"] = next_checkpoint(state, args.task,
+                                          args.checkpoint_step, args.checkpoint_note)
+    if args.agent or args.model:
+        updated_by = dict(state.get("updated_by") or {})
+        if args.agent:
+            if len(args.agent) > LIMITS["updated_by.agent"]:
+                die(f"--agent exceeds {LIMITS['updated_by.agent']} chars")
+            updated_by["agent"] = args.agent
+        if args.model:
+            if len(args.model) > LIMITS["updated_by.model"]:
+                die(f"--model exceeds {LIMITS['updated_by.model']} chars")
+            updated_by["model"] = args.model
+        state["updated_by"] = updated_by
+
+    if state["status"] not in PLAN_STATUSES:
+        die(f"internal: derived invalid plan status {state['status']!r}")
+
+    # Sanity guards for the fields this tool owns, before anything is written.
+    for t in tasks:
+        if t["status"] not in TASK_STATUSES:
+            die(f"task {t.get('id')} has invalid status {t['status']!r}")
+    if not 0 <= state["completed_count"] <= state.get("task_count", len(tasks)):
+        die("completed_count out of range")
+
+    directory = os.path.dirname(os.path.abspath(args.state))
+    payload = json.dumps(state, indent=2, ensure_ascii=False) + "\n"
+    fd, tmp_path = tempfile.mkstemp(dir=directory, prefix=".state.json.", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(payload)
+        os.replace(tmp_path, args.state)
+    except BaseException:
+        if os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+        raise
+
+    print(f"task {args.task} → {args.status} · "
+          f"{state['completed_count']}/{state['task_count']} completed · "
+          f"plan {state['status']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/deepworkplan/spec/PLAN_STATE.md
+++ b/.agents/skills/deepworkplan/spec/PLAN_STATE.md
@@ -288,7 +288,12 @@ Conforms to [`schema/plan-state.schema.json`](schema/plan-state.schema.json)
   order: the task file's Completion & Log → the plan README checkboxes and status
   → `PROGRESS.md` → `state.json` (atomic replace). The markdown is therefore
   never behind the projection; a crash between steps leaves a state file that is
-  at worst *stale*, never *ahead* of the truth.
+  at worst *stale*, never *ahead* of the truth. For the `state.json` step a
+  targeted mutation **SHOULD** use the shipped updater
+  (`shared/update-state.py`, stdlib-only, atomic, idempotent modulo
+  timestamps) rather than re-emitting the whole file; whole-file regeneration
+  remains the path for creation, `refine` recounts, and markdown-wins
+  reconciliation.
 - **Interruption before or after the commit.** On resume the agent **MUST**
   inspect actual evidence before replaying anything: `git status` and `git log`
   (where git exists), the task log, the README checkbox, and `state.json`. Work

--- a/.agents/skills/deepworkplan/status/SKILL.md
+++ b/.agents/skills/deepworkplan/status/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-status
 description: Report Lite or Full Deep Work Plan status — format, approval, readiness, progress, checkpoint, blockers and Markdown/state consistency — without modifying anything.
-version: "4.0.3"
+version: "5.0.0"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob

--- a/.agents/skills/deepworkplan/upgrade/SKILL.md
+++ b/.agents/skills/deepworkplan/upgrade/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-upgrade
 description: Check whether a newer DeepWorkPlan skill and DWP standard exists and — only after the developer explicitly accepts — install the latest published tag through the documented channel and re-run onboarding exactly as if https://deepworkplan.com/init.md were executed fresh, preserving every plan under .dwp/ and surfacing local adaptations instead of silently overwriting them. Use when the developer asks to upgrade, update, or refresh DWP in a repository that already has it installed. Do not use it to onboard a repo for the first time (that is the onboard sub-skill) or to migrate an old plan's shape (that is refine migrate, and plans are never migrated by an upgrade).
-version: "4.0.3"
+version: "5.0.0"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write

--- a/.agents/skills/deepworkplan/verify/SKILL.md
+++ b/.agents/skills/deepworkplan/verify/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-verify
 description: Verify that a repository is DeepWorkPlan-conformant (AI-first) and that its plans are well-formed, producing an objective pass/fail report. Use when the developer asks to verify, audit, or check conformance of a repo or a plan.
-version: "4.0.3"
+version: "5.0.0"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,7 +115,7 @@ deepworkplan-skill/
 └── skills/deepworkplan/                        ← THE INSTALLED ARTIFACT — only this ships
     ├── SKILL.md                                ← router (version source of truth)
     ├── spec/                                   ← the 5 RFC-2119 normative docs (the standard; ships)
-    ├── shared/                                 ← context.sh, dwp-paths.md, adaptation.md
+    ├── shared/                                 ← context.sh, dwp-paths.md, adaptation.md, troubleshooting.md, update-state.py
     ├── create/SKILL.md                         ← create a Deep Work Plan
     ├── execute/SKILL.md                        ← execute a plan task-by-task
     ├── refine/SKILL.md                         ← modify a plan / promote Lite to Full
@@ -292,7 +292,7 @@ Co-Authored-By: <agent name + version> <noreply@anthropic.com>
 
 **Scopes:** `skill` (general pack/router), `create` / `execute` / `refine` /
 `resume` / `status` / `onboard` (specific sub-skill), `addon` (an addon under
-`addons/`), `shared` (context.sh, dwp-paths.md, adaptation.md), `setup`
+`addons/`), `shared` (context.sh, dwp-paths.md, adaptation.md, update-state.py), `setup`
 (setup.sh), `ci` (.github/), `docs` (docs/, README, guide), `release`
 (versioning, CHANGELOG).
 

--- a/docs/adr/0002-plan-state-format.md
+++ b/docs/adr/0002-plan-state-format.md
@@ -1,0 +1,108 @@
+# ADR 0002 — Plan-state file format: retain JSON, ship a targeted updater
+
+| Field | Value |
+|-------|-------|
+| **Status** | Accepted (applied on `feat/v5-phase2`) |
+| **Date** | 2026-09-12 |
+| **Skill baseline** | `ab1337d` (released `v5.0.0`) |
+| **Scope** | `skills/deepworkplan/spec/` (state-layer contract), `skills/deepworkplan/shared/` (new updater), flow texts that instruct `state.json` writes |
+| **Relates to** | [ADR 0001](0001-token-efficiency-architecture.md) (token-efficiency architecture — same governing principle) |
+| **Supersedes** | — (first decision on plan-file syntax) |
+
+## 1. Context
+
+DWP plans carry two JSON artifacts: `manifest.json` (identity, written once at
+create) and `state.json` (live execution state, updated at every protocol
+point). A 2026-09-12 review asked whether a more agent-friendly serialization
+— specifically **TOON** (Token-Oriented Object Notation, spec v4.1), alongside
+TOML, YAML, and JSONL/per-task splits — would materially cut token cost for
+long plans. The review measured the predecessor 25-task plan's files directly
+(filesystem bytes; no token or cost conversions) and evaluated each candidate
+against the pack's hard floors.
+
+### 1.1 Measured reality (predecessor plan, 25 tasks completed)
+
+| Fact | Value |
+|------|-------|
+| `manifest.json` | 331 B, 10 lines — written **once**, read by 11 skill/spec surfaces |
+| `state.json` | 60,329 B, 1,194 lines — whole-file rewritten at every protocol point |
+| Composition of `state.json` | per-task `gates[]` evidence 56% · bare task skeleton 11% · outcome/timestamps/commit 33% |
+| Agent-emit across the plan's life | ≈ 843 KB — **quadratic**: at task *k* the executor re-emits ≈ 6.7 KB + 2.26 KB·k, so every evidence string is re-emitted once per later completion |
+| Compact-JSON bracket on the same file | 48,425 B = 20% byte saving (the honest floor any whitespace-based swap at least matches) |
+| Key-elimination (tabular) bracket | ≈ 33 KB ≈ 45% byte saving |
+| Verifier parse floor | `verify/conformance.sh` → `plan_contract.py` reads both files with **Python 3.9+ stdlib `json`** — the honest-verifier contract (no capable interpreter → exit 2 `UNVERIFIED`) |
+
+## 2. Decision
+
+1. **`manifest.json` and `state.json` stay JSON.** Schemas
+   (`spec/schema/plan-{manifest,state}-v2.schema.json`), the verifier, and all
+   32 documentation surfaces are unchanged.
+2. **The pack ships a targeted state updater** —
+   `skills/deepworkplan/shared/update-state.py`, stdlib-only (Python 3.9+),
+   atomic (temp file + rename), idempotent modulo timestamps — so an executor
+   applies a task close as a bounded delta (status, gate records, outcome,
+   commit, counts, checkpoint) instead of re-emitting the whole file.
+   Emit cost across the same 25-task plan drops from ≈ 843 KB to ≈ 62 KB
+   (**−93%**), removing the quadratic term entirely: evidence is emitted
+   exactly once, when earned.
+3. **Flow texts point at it.** `execute` (task close), `resume` (update-order
+   tail), and `spec/PLAN_STATE.md` §5.1 teach the one-line invocation; a
+   whole-file rewrite remains the documented fallback, and markdown-wins
+   reconciliation (§5) stays a whole-file regeneration by design.
+
+## 3. Why the alternatives lost
+
+- **TOON** — no stdlib parser in any language (official SDK is TypeScript;
+  the Python implementation is a separate, unverified package), spec v4.1
+  self-describes as "an idea in progress", multi-line string escaping is
+  unspecified, and DWP's `tasks[]` is *semi-uniform* (optional keys, 0–4
+  gates, evidence strings containing commas/colons/quotes) — exactly the shape
+  their own limitations section says shrinks or reverses savings. It optimizes
+  files *fed into prompts*; DWP state files are *emitted by agents and read by
+  tooling*. Breaking the verifier's stdlib floor would convert the honesty
+  guarantee into an install step.
+- **TOML** — `tomllib` is 3.11+ and read-only; below the 3.9 floor there is no
+  stdlib story at all.
+- **YAML** — a PyYAML dependency plus the classic indentation failure mode
+  under agent edits, for the same whole-file rewrite cost.
+- **JSONL / per-task split** — keeps stdlib parsing and makes emits O(task),
+  but sacrifices closed top-level invariants (`completed_count`, derived plan
+  status) and restructures every consumer for a benefit the updater already
+  delivers against the unchanged layout.
+- **Pure syntax swap (compact JSON)** — the 20–45% byte bracket shrinks the
+  base but keeps the quadratic emit term; the updater removes it.
+
+The governing principle is ADR 0001's: **compress the scaffolding, never the
+instructions.** The cost was never JSON's syntax; it was the whole-file
+rewrite pattern.
+
+## 4. Consequences
+
+- Executors emit one bounded delta per completion; gate evidence stops being
+  re-emitted by every later task.
+- New runtime surface: one script inside the pack (`shared/update-state.py`),
+  covered by contract tests (`tests/state-updater.bats`) that run the real
+  script against a fixture plan and assert schema validity, atomicity, and
+  idempotence modulo timestamps.
+- The updater never authors plan-level `blocked` (that record carries a reason
+  and timestamp owned by the blocked protocol), never touches `manifest.json`,
+  and never invents fields — its output validates against the closed v2 schema
+  wherever its input did.
+- Markdown remains the source of truth; reconciliation stays whole-file by
+  design (PLAN_STATE.md §5).
+
+## 5. What would reopen this decision
+
+- TOON (or a successor) ships a **stdlib-grade or vendored-zero-dependency
+  Python parser with write support** and schema tooling, and freezes
+  multi-line string escaping; or
+- plan files become agent-*read* hot paths whose bytes actually enter prompts
+  (e.g. a future flow inlining state into prompts); or
+- measurements (the evaluation record's reproduce commands, plus the updater's
+  own usage) show agents bypassing the updater and still whole-file rewriting —
+  then a harder structural change (per-task split) reopens.
+
+Unverified and quarantined as such: the exact TOON byte delta on a real
+`state.json` (no stdlib encoder available to measure honestly — the 20%/45%
+figures are JSON-compact and key-elimination arithmetic, not a TOON
+measurement) and `toon-python`'s PyPI name/version/write support.

--- a/docs/evaluations/hardening-2026-09.md
+++ b/docs/evaluations/hardening-2026-09.md
@@ -154,3 +154,40 @@ python3 scripts/check-schema-contract.py
 
 Numbers may legitimately differ only if `skills/deepworkplan/` changed since
 `6847ea1`; the digest comparison above detects exactly that.
+
+## Released tree (v5.0.0 — `ab1337d`)
+
+The "final" baseline above is `6847ea1`, the hardening branch after its last
+`skills/deepworkplan/` change. The release then landed one more pack commit
+(`199ec1b`: author-sub-skill hardening, plan-local `analysis_results` contract —
+the latter edited `shared/dwp-paths.md`, which is in every flow's compulsory
+read set) plus the version stamp. For the released tag the numbers are:
+
+| Flow | final (`6847ea1`) | **released v5.0.0 (`ab1337d`)** | delta |
+|---|---:|---:|---:|
+| create | 99,573 | 100,012 | +439 |
+| execute | 83,615 | 84,128 | +513 |
+| resume | 78,315 | 78,754 | +439 |
+| onboard | 69,903 | 70,342 | +439 |
+
+Measured with the same method (git-archive export, committed script — md5
+`da7709ce…` unchanged at `ab1337d`); read-set composition is unchanged —
+growth is byte growth in already-read files. Digest of the released pack:
+
+```text
+git archive --format=tar ab1337d -- skills/deepworkplan | sha256sum
+ae8c1577cc6bb08c638464af06a8ea768b216618894a4fc45c22585239819f2b
+```
+
+Contract suite at the released tag: **258 tests, 257 passing** — the release
+stamp rewrote every `version:` frontmatter to `5.0.0` but no test literals,
+leaving one hardcoded `4.0.3` pin red (`tests/upgrade-subskill.bats` test 1;
+the stamp commit is `[skip ci]`, so CI did not surface it). Fixed on branch
+`feat/v5-phase2` by deriving the pin from the router's own frontmatter. That
+branch also adds the two missing command-kit templates and Lite-Context
+authoring fixes, touching `onboard/SKILL.md` and `create/SKILL.md` — the next
+release should cut a fresh row here rather than extrapolate.
+
+Recorded 2026-09-12 during the v5 phase-2 field validation (finding F1-1:
+the record previously stopped at `6847ea1` and called it "final" while the
+shipped tree differed).

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -17,7 +17,7 @@
       "source": "DailybotHQ/deepworkplan-skill",
       "sourceType": "github",
       "skillPath": "skills/deepworkplan/SKILL.md",
-      "computedHash": "19d767bcd7e1fca407bf9f586b091a7f5e6017644561071fe88412e6ee20213a"
+      "computedHash": "00fb434e8a4b617e6df937ae75c17fe5c591c5758e903b6314223625de831352"
     }
   }
 }

--- a/skills/deepworkplan/create/SKILL.md
+++ b/skills/deepworkplan/create/SKILL.md
@@ -387,7 +387,8 @@ One concise record here; machine state is derived from it, never duplicated.
 ## 7. Plan Status / Notes    → `Plan Status: 0/N completed`
 
 ## Task 1 {#task-1}
-**Goal** · **Touched Surface** (planned surface, risk class, test mapping,
+**Goal** · **Context** (what a fresh session needs to start this task alone) ·
+**Touched Surface** (planned surface, risk class, test mapping,
 selected gate and why) · **Acceptance Criteria** · **Validation** (a runnable
 command) · **Completion log** (status, skills disposition, gate record).
 
@@ -595,8 +596,8 @@ and the Final Review is always sequential.
 - Task IDs are contiguous `1..N`; each `{#task-N}` anchor occurs exactly once;
   every Task List link resolves to its anchor; the Final Review is task `N` and
   the only final task.
-- Every task record has a Goal, a Touched Surface, Acceptance Criteria, a
-  runnable Validation gate and a completion-log placeholder. No task was padded
+- Every task record has a Goal, a Context, a Touched Surface, Acceptance
+  Criteria, a runnable Validation gate and a completion-log placeholder. No task was padded
   in to reach a count.
 - `manifest.json` validates against the v2 manifest schema with
   `plan_format: "lite"`; `state.json` validates against the v2 state schema, its

--- a/skills/deepworkplan/execute/SKILL.md
+++ b/skills/deepworkplan/execute/SKILL.md
@@ -305,6 +305,14 @@ Rules (strict):
    else, so a plan whose gates carry an invented field fails verification even
    though its work is done (`../spec/PLAN_STATE.md` §4.2).
 
+   Prefer the shipped updater for this close step — it applies exactly the
+   delta above (status, gates, outcome, commit, counts, checkpoint) atomically
+   and its output is closed-schema-valid where the input was:
+   `python3 ../shared/update-state.py <plan>/state.json --task N --status completed --commit <hash> --gate '<command>|<exit>|<evidence>' --worked '<one line>'`.
+   A whole-file rewrite of `state.json` remains the documented fallback when
+   scripting is genuinely unavailable; reconciliation from markdown (§5) is
+   always a whole-file regeneration.
+
 7. **Dailybot per-task report (only for individually significant tasks)** — after
    committing a task that is independently significant (feature, bug fix, major
    refactor), trigger the `dailybot` skill (e.g. "report this to Dailybot" or

--- a/skills/deepworkplan/onboard/SKILL.md
+++ b/skills/deepworkplan/onboard/SKILL.md
@@ -565,8 +565,9 @@ and **stack-appropriate**, not generic boilerplate.
   `security-auditor`, plus any **stack-specific** role the preset suggests
   (e.g. a Django `migration-author`, a Vue `component-author`). Each persona
   must be described well enough that a non-Claude agent can read it.
-- **`.agents/commands/`** — the six short DWP commands (`dwp-create`,
-  `dwp-execute`, `dwp-refine`, `dwp-resume`, `dwp-status`, `dwp-verify`) plus stack-relevant
+- **`.agents/commands/`** — the seven short DWP commands (`dwp-create`,
+  `dwp-execute`, `dwp-refine`, `dwp-resume`, `dwp-status`, `dwp-verify`,
+  `dwp-upgrade`) plus stack-relevant
   ones (`code-review`, `pr`, `commit`, `branch`). **The `dwp-*` commands MUST be
   thin delegators, NOT copies of the flow.** Each is a short file (frontmatter
   `description:` + a body) that routes the invocation to the matching sub-skill
@@ -598,6 +599,9 @@ and **stack-appropriate**, not generic boilerplate.
 > **Existing-repo note:** if `.agents/` (or per-tool `.claude/` / `.cursor/`)
 > config already exists, reconcile into `.agents/` and add the `.claude` and
 > `.cursor` symlinks only if absent; never delete existing personas/commands without asking.
+> A tool-created `.claude/` / `.cursor/` directory whose only content is symlinks
+> into `.agents/` may be converted to the canonical root symlink outright — that
+> is a zero-loss reconciliation, not a deletion.
 > On a **harness upgrade** (Phase 0), refresh the `dwp-*`, `skill-create` and
 > `agent-create` delegators from `command-templates/` (they are thin and owned
 > by the skill), leave every other command, agent and skill as-is, and update
@@ -696,9 +700,9 @@ done.
 5. **`.agents/`** has `agents/`, `commands/`, `skills/`, `docs/`, `settings.json`
    and `.claude → .agents` + `.cursor → .agents` symlinks (or documented fallback);
    `skills_agents_catalog.md` and `COMMANDS_REFERENCE.md` **match** what was
-   actually created (no phantom entries). **The six `dwp-*` commands exist** in
+   actually created (no phantom entries). **The seven `dwp-*` commands exist** in
    `.agents/commands/` (`dwp-create`, `dwp-execute`, `dwp-refine`, `dwp-resume`,
-   `dwp-status`, `dwp-verify`) and are thin delegators (no leftover `<skill-path>`
+   `dwp-status`, `dwp-verify`, `dwp-upgrade`) and are thin delegators (no leftover `<skill-path>`
    placeholder, no copied flow body).
 6. **DeepWorkPlan skill is discoverable** and `.dwp/` exists, is gitignored
    (`git check-ignore .dwp` confirms), and has `plans/`. **`tmp/`

--- a/skills/deepworkplan/onboard/command-templates/dwp-upgrade.md
+++ b/skills/deepworkplan/onboard/command-templates/dwp-upgrade.md
@@ -10,7 +10,7 @@ description: Check for a newer DeepWorkPlan skill and upgrade only with explicit
 ## What to do
 
 Route this invocation to the **upgrade** sub-skill of the installed `deepworkplan`
-skill and follow it: read `.agents/skills/deepworkplan/upgrade/SKILL.md` and execute
+skill and follow it: read `<skill-path>/deepworkplan/upgrade/SKILL.md` and execute
 its flow. The check phase is **read-only**; nothing installs without your explicit
 acceptance, and `.dwp/` plan history is never migrated by an upgrade.
 

--- a/skills/deepworkplan/onboard/command-templates/dwp-verify.md
+++ b/skills/deepworkplan/onboard/command-templates/dwp-verify.md
@@ -1,0 +1,19 @@
+---
+description: Verify repo/plan conformance against the DWP spec (read-only) (provided by the installed `deepworkplan` skill)
+---
+
+# /dwp-verify — provided by the `deepworkplan` skill
+
+> Thin alias. The flow lives in the installed `deepworkplan` skill — this file
+> only routes to it, so there is a single source of truth and no drift.
+
+## What to do
+
+Route this invocation to the **verify** sub-skill of the installed `deepworkplan`
+skill and follow it: read `<skill-path>/deepworkplan/verify/SKILL.md` and execute
+its flow. This is a **read-only** conformance check (repo onboarding state or a
+plan against the spec) — it reports findings and never mutates files.
+
+> Other agents: invoke the skill's `deepworkplan-verify` sub-skill directly
+> (`/deepworkplan-verify` in Claude Code, `#deepworkplan-verify` elsewhere). This
+> `dwp-verify` file is the shorter, conventional alias.

--- a/skills/deepworkplan/resume/SKILL.md
+++ b/skills/deepworkplan/resume/SKILL.md
@@ -143,7 +143,10 @@ pointer**, never by replaying everything.
    | mid-implementation with no checkpoint note | dirty tree only | review the diff against the task; incorporate valid partial progress, finish the rest |
 
    Changed inputs since a recorded gate (a later edit, a `refine`, a new
-   revision) invalidate that gate → rerun it.
+   revision) invalidate that gate → rerun it. Where the table resumes the
+   tail of the update order, the `state.json` step may use the shipped
+   updater (`../shared/update-state.py`) as a targeted, atomic mutation;
+   only the reconcile-from-markdown row regenerates the whole file.
 6. **Takeover from another agent or model.** If the checkpoint, log or
    `PROGRESS.md` was written by a different agent/model (`state.json.updated_by`,
    the log's wording) or the session is a fresh context: read the checkpoint

--- a/skills/deepworkplan/shared/update-state.py
+++ b/skills/deepworkplan/shared/update-state.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Apply a targeted mutation to a Deep Work Plan state.json (v2 schema).
+
+The state layer stays JSON (ADR 0002); this helper exists so an executing
+agent applies a task-close or status change as a bounded delta — set one
+task's status, attach its gate records and outcome, recompute counts and the
+checkpoint — instead of re-emitting the whole file from context. It writes
+atomically (temp file + rename) and only ever assigns fields the closed v2
+schema knows, so its output validates where the input did.
+
+Stdlib only (Python 3.9+). It mutates exactly one file: the state.json given
+as the first argument. Whole-file regeneration (create, refine recount,
+markdown-wins reconciliation) stays a manual, documented operation.
+
+Usage:
+  update-state.py STATE.json --task N --status completed \
+      [--gate "command|exit_code|evidence"] [--gate ...] \
+      [--worked "one line"] [--notes "pointer"] [--commit <sha>] \
+      [--checkpoint-step "step"] [--checkpoint-note "note"] \
+      [--agent <name>] [--model <name>]
+
+Exit codes: 0 applied · 1 validation error (nothing written) · 2 usage.
+"""
+import argparse
+import datetime
+import json
+import os
+import re
+import sys
+import tempfile
+
+TASK_STATUSES = ("pending", "in_progress", "completed", "blocked", "skipped")
+PLAN_STATUSES = ("pending", "in_progress", "completed", "blocked")
+COMMIT_RE = re.compile(r"^[0-9a-f]{7,40}$")
+# Closed-schema field budgets (plan-state-v2.schema.json) enforced on write.
+LIMITS = {
+    "gate.command": 500, "gate.evidence": 500,
+    "outcome.worked": 500, "outcome.notes": 1000,
+    "checkpoint.step": 200, "checkpoint.note": 500,
+    "updated_by.agent": 100, "updated_by.model": 100,
+}
+
+
+def die(msg, code=1):
+    print(f"update-state: {msg}", file=sys.stderr)
+    sys.exit(code)
+
+
+def now():
+    return datetime.datetime.now(datetime.timezone.utc).isoformat()
+
+
+def parse_gates(raw):
+    """Each --gate is 'command|exit_code|evidence'."""
+    gates = []
+    for spec in raw:
+        parts = spec.split("|", 2)
+        if len(parts) != 3:
+            die(f"--gate expects 'command|exit_code|evidence', got: {spec!r}")
+        command, exit_code, evidence = (p.strip() for p in parts)
+        try:
+            code = int(exit_code)
+        except ValueError:
+            die(f"--gate exit_code is not an integer: {exit_code!r}")
+        if len(command) > LIMITS["gate.command"]:
+            die(f"gate command exceeds {LIMITS['gate.command']} chars")
+        if len(evidence) > LIMITS["gate.evidence"]:
+            die(f"gate evidence exceeds {LIMITS['gate.evidence']} chars")
+        gates.append({"command": command, "passes": code == 0,
+                      "last_run": now(), "exit_code": code,
+                      "evidence": evidence})
+    return gates
+
+
+def derive_plan_status(state):
+    tasks = state["tasks"]
+    if all(t["status"] in ("completed", "skipped") for t in tasks):
+        return "completed"
+    if any(t["status"] == "in_progress" for t in tasks):
+        return "in_progress"
+    if state["completed_count"] > 0:
+        return "in_progress"
+    return "pending"
+
+
+def next_checkpoint(state, task_id, step, note):
+    pending = [t["id"] for t in state["tasks"]
+               if t["status"] not in ("completed", "skipped")]
+    if pending:
+        target = min(pending)
+        step = step or "start"
+        note = note or f"Task {task_id} closed. Next: Task {target}."
+    else:
+        target = task_id
+        step = step or "done"
+        note = note or "Plan completed."
+    if len(step) > LIMITS["checkpoint.step"]:
+        die(f"checkpoint step exceeds {LIMITS['checkpoint.step']} chars")
+    if len(note) > LIMITS["checkpoint.note"]:
+        die(f"checkpoint note exceeds {LIMITS['checkpoint.note']} chars")
+    return {"task": target, "step": step, "at": now(), "note": note}
+
+
+def main():
+    ap = argparse.ArgumentParser(add_help=True, description=__doc__.splitlines()[0])
+    ap.add_argument("state", help="path to the plan's state.json")
+    ap.add_argument("--task", type=int, required=True, metavar="N")
+    ap.add_argument("--status", required=True, choices=TASK_STATUSES)
+    ap.add_argument("--gate", action="append", default=[], metavar="CMD|EXIT|EVIDENCE")
+    ap.add_argument("--worked", default="")
+    ap.add_argument("--notes", default="")
+    ap.add_argument("--commit", default="")
+    ap.add_argument("--checkpoint-step", default="")
+    ap.add_argument("--checkpoint-note", default="")
+    ap.add_argument("--agent", default="")
+    ap.add_argument("--model", default="")
+    args = ap.parse_args()
+
+    for field, value in (("outcome.worked", args.worked), ("outcome.notes", args.notes)):
+        if len(value) > LIMITS[field]:
+            die(f"--{field.split('.')[1]} exceeds {LIMITS[field]} chars")
+    if args.commit and not COMMIT_RE.match(args.commit):
+        die(f"--commit is not a commit hash: {args.commit!r}")
+    if args.state not in ("", ) and not os.path.isfile(args.state):
+        die(f"state file not found: {args.state}")
+
+    try:
+        with open(args.state, encoding="utf-8") as fh:
+            state = json.load(fh)
+    except (OSError, json.JSONDecodeError) as exc:
+        die(f"cannot read state: {exc}")
+
+    tasks = state.get("tasks") or []
+    task = next((t for t in tasks if t.get("id") == args.task), None)
+    if task is None:
+        die(f"no task {args.task} in this plan "
+            f"(have: {[t.get('id') for t in tasks]})")
+
+    stamp = now()
+    if task["status"] != args.status:
+        # Idempotence: timestamps record when a transition happened, so a
+        # replayed invocation keeps the original reading.
+        if args.status in ("in_progress", "completed", "blocked") and not task.get("started_at"):
+            task["started_at"] = stamp
+        if args.status == "completed" and not task.get("completed_at"):
+            task["completed_at"] = stamp
+    task["status"] = args.status
+    if args.commit:
+        task["commit"] = args.commit
+    if args.worked or args.notes:
+        outcome = dict(task.get("outcome") or {})
+        if args.worked:
+            outcome["worked"] = args.worked
+        if args.notes:
+            outcome["notes"] = args.notes
+        task["outcome"] = outcome
+    if args.gate:
+        task["gates"] = parse_gates(args.gate)
+
+    state["completed_count"] = sum(1 for t in tasks if t["status"] == "completed")
+    # Plan-level `blocked` carries its own record (reason/since) authored by
+    # the blocked protocol; this helper never guesses it.
+    state["status"] = derive_plan_status(state)
+    state["updated_at"] = stamp
+    state["checkpoint"] = next_checkpoint(state, args.task,
+                                          args.checkpoint_step, args.checkpoint_note)
+    if args.agent or args.model:
+        updated_by = dict(state.get("updated_by") or {})
+        if args.agent:
+            if len(args.agent) > LIMITS["updated_by.agent"]:
+                die(f"--agent exceeds {LIMITS['updated_by.agent']} chars")
+            updated_by["agent"] = args.agent
+        if args.model:
+            if len(args.model) > LIMITS["updated_by.model"]:
+                die(f"--model exceeds {LIMITS['updated_by.model']} chars")
+            updated_by["model"] = args.model
+        state["updated_by"] = updated_by
+
+    if state["status"] not in PLAN_STATUSES:
+        die(f"internal: derived invalid plan status {state['status']!r}")
+
+    # Sanity guards for the fields this tool owns, before anything is written.
+    for t in tasks:
+        if t["status"] not in TASK_STATUSES:
+            die(f"task {t.get('id')} has invalid status {t['status']!r}")
+    if not 0 <= state["completed_count"] <= state.get("task_count", len(tasks)):
+        die("completed_count out of range")
+
+    directory = os.path.dirname(os.path.abspath(args.state))
+    payload = json.dumps(state, indent=2, ensure_ascii=False) + "\n"
+    fd, tmp_path = tempfile.mkstemp(dir=directory, prefix=".state.json.", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(payload)
+        os.replace(tmp_path, args.state)
+    except BaseException:
+        if os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+        raise
+
+    print(f"task {args.task} → {args.status} · "
+          f"{state['completed_count']}/{state['task_count']} completed · "
+          f"plan {state['status']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/deepworkplan/spec/PLAN_STATE.md
+++ b/skills/deepworkplan/spec/PLAN_STATE.md
@@ -288,7 +288,12 @@ Conforms to [`schema/plan-state.schema.json`](schema/plan-state.schema.json)
   order: the task file's Completion & Log → the plan README checkboxes and status
   → `PROGRESS.md` → `state.json` (atomic replace). The markdown is therefore
   never behind the projection; a crash between steps leaves a state file that is
-  at worst *stale*, never *ahead* of the truth.
+  at worst *stale*, never *ahead* of the truth. For the `state.json` step a
+  targeted mutation **SHOULD** use the shipped updater
+  (`shared/update-state.py`, stdlib-only, atomic, idempotent modulo
+  timestamps) rather than re-emitting the whole file; whole-file regeneration
+  remains the path for creation, `refine` recounts, and markdown-wins
+  reconciliation.
 - **Interruption before or after the commit.** On resume the agent **MUST**
   inspect actual evidence before replaying anything: `git status` and `git log`
   (where git exists), the task log, the README checkbox, and `state.json`. Work

--- a/tests/agents-dogfood.bats
+++ b/tests/agents-dogfood.bats
@@ -45,8 +45,8 @@ setup() {
     [ -f "$AGENTS_DIR/README.md" ]
 }
 
-@test "the six dwp-* delegators plus skill-create/agent-create exist" {
-    for c in dwp-create dwp-execute dwp-refine dwp-resume dwp-status dwp-verify skill-create agent-create; do
+@test "the seven dwp-* delegators plus skill-create/agent-create exist" {
+    for c in dwp-create dwp-execute dwp-refine dwp-resume dwp-status dwp-verify dwp-upgrade skill-create agent-create; do
         [ -f "$AGENTS_DIR/commands/$c.md" ]
     done
 }

--- a/tests/context-enforcement.bats
+++ b/tests/context-enforcement.bats
@@ -63,3 +63,13 @@ c_doc_has() {
     grep -qF '## 1. Context' "$SK/examples/TEAM_AGENTS_TASK_TEMPLATE.md"
     grep -qF '## 2. Context' "$SK/examples/ORCHESTRATOR_TASK_TEMPLATE_create_child_dwp.md"
 }
+
+@test "create teaches the per-task Context the verifier enforces (Lite anatomy + Step 4.5)" {
+    # F6-1: the verifier requires non-empty Context for every non-completed
+    # Lite task record, but the Lite README anatomy and the Step 4.5 quality
+    # checklist omitted the field — a plan authored exactly per the anatomy
+    # failed conformance until every task completed.
+    CREATE="$SK/create/SKILL.md"
+    c_doc_has "$CREATE" "**Goal** · **Context**"
+    c_doc_has "$CREATE" "has a Goal, a Context, a Touched Surface"
+}

--- a/tests/onboard-command-kit.bats
+++ b/tests/onboard-command-kit.bats
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Contract tests for the onboarding command kit (findings F3-1, F4-1, F3-4 of
+# PLAN_v5_phase2_validation): every dwp-* command Phase 6 names must ship a
+# ready delegator template (the released v5.0.0 kit shipped five templates for
+# six named commands and none for /dwp-upgrade, so a freshly onboarded repo
+# had no command-file path to the upgrade flow), Phase 8's checklist must
+# require the same set, and the Phase 6 existing-repo note must cover the
+# zero-loss conversion of tool-created symlink-only directories.
+#
+# Run with:  bats tests/
+# Requires:  bats-core
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    SK="$REPO_ROOT/skills/deepworkplan"
+    ONBOARD="$SK/onboard/SKILL.md"
+    TPL="$SK/onboard/command-templates"
+}
+
+@test "every dwp-* command Phase 6 names ships a delegator template" {
+    # Extract the kit enumeration itself (the parenthesized list after "short
+    # DWP commands"), not every dwp- token in the file — prose mentions like
+    # `dwp-*` or shared/dwp-paths.md are not commands.
+    flat="$(tr '\n' ' ' < "$ONBOARD" | tr -s ' ')"
+    names="$(printf '%s\n' "$flat" \
+        | sed 's/.*short DWP commands (\([^)]*\)).*/\1/' \
+        | tr -d '\`,' | tr ' ' '\n' | grep -v '^$' | sort -u)"
+    [ -n "$names" ]
+    n=0
+    for c in $names; do
+        [ -f "$TPL/$c.md" ]
+        n=$((n + 1))
+    done
+    [ "$n" -ge 7 ]
+}
+
+@test "dwp-verify.md template exists, is thin and routes to the verify sub-skill" {
+    [ -f "$TPL/dwp-verify.md" ]
+    lines="$(wc -l < "$TPL/dwp-verify.md")"
+    [ "$lines" -le 40 ]
+    grep -q '^description: ' "$TPL/dwp-verify.md"
+    grep -q '\*\*verify\*\* sub-skill' "$TPL/dwp-verify.md"
+    grep -q '<skill-path>/deepworkplan/verify/SKILL.md' "$TPL/dwp-verify.md"
+    grep -qi 'read-only' "$TPL/dwp-verify.md"
+}
+
+@test "dwp-upgrade.md template exists, is thin and routes to the upgrade sub-skill" {
+    [ -f "$TPL/dwp-upgrade.md" ]
+    lines="$(wc -l < "$TPL/dwp-upgrade.md")"
+    [ "$lines" -le 40 ]
+    grep -q '^description: ' "$TPL/dwp-upgrade.md"
+    grep -q '\*\*upgrade\*\* sub-skill' "$TPL/dwp-upgrade.md"
+    grep -q '<skill-path>/deepworkplan/upgrade/SKILL.md' "$TPL/dwp-upgrade.md"
+    grep -qi 'explicit' "$TPL/dwp-upgrade.md"
+}
+
+@test "Phase 6 names dwp-upgrade among the kit commands and Phase 8 checks it" {
+    grep -q 'dwp-upgrade' "$ONBOARD"
+    # Phase 8's self-check must require the full set including dwp-upgrade.
+    phase8="$(sed -n '/## Phase 8/,$p' "$ONBOARD")"
+    echo "$phase8" | grep -q 'dwp-upgrade'
+    # And the kit count must match reality, not a stale "six".
+    echo "$phase8" | grep -q 'seven `dwp-\*` commands'
+}
+
+@test "Phase 6 existing-repo note covers zero-loss conversion of symlink-only tool dirs" {
+    # F3-4: a tool-created .claude/ holding only symlinks into .agents/ converts
+    # to the canonical root symlink — that is reconciliation, not deletion.
+    tr '\n' ' ' < "$ONBOARD" | tr -s ' ' | grep -qF 'only content is symlinks'
+    tr '\n' ' ' < "$ONBOARD" | tr -s ' ' | grep -qF 'zero-loss'
+}

--- a/tests/state-updater.bats
+++ b/tests/state-updater.bats
@@ -1,0 +1,147 @@
+#!/usr/bin/env bats
+# Contract tests for the shipped state updater (format decision of
+# PLAN_v5_phase2_validation): manifest.json/state.json stay JSON, and the pack
+# ships a stdlib-only Python helper so executors apply targeted mutations
+# (task status, gate evidence, counts/checkpoint) instead of re-emitting the
+# whole state file on every task. The tests run the REAL script against a
+# copy of the lite-plan fixture and assert schema validity, atomicity and
+# idempotence-modulo-timestamps.
+#
+# Run with:  bats tests/
+# Requires:  bats-core, python3 (jsonschema optional — schema assertions skip)
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    SCRIPT="$REPO_ROOT/skills/deepworkplan/shared/update-state.py"
+    SCHEMA="$REPO_ROOT/skills/deepworkplan/spec/schema/plan-state-v2.schema.json"
+    FX="$REPO_ROOT/tests/fixtures/lite-plan/.dwp/plans/PLAN_lite_fixture"
+    WORK="$(mktemp -d)"
+    cp "$FX/state.json" "$WORK/state.json"
+}
+
+teardown() { rm -rf "$WORK"; }
+
+# Assert $WORK/state.json validates against the shipped v2 schema (skipped
+# when jsonschema is not installed — same guard as schema-contract.bats).
+validates() {
+    python3 -c 'import jsonschema' 2>/dev/null || skip "jsonschema not installed"
+    python3 - "$SCHEMA" "$WORK/state.json" <<'PY'
+import json, sys, pathlib
+from jsonschema import Draft202012Validator
+schema = json.loads(pathlib.Path(sys.argv[1]).read_text())
+state = json.loads(pathlib.Path(sys.argv[2]).read_text())
+errors = list(Draft202012Validator(schema).iter_errors(state))
+assert not errors, "\n".join(e.message for e in errors)
+PY
+}
+
+@test "the updater ships inside the pack and is stdlib-only" {
+    [ -f "$SCRIPT" ]
+    # Runtime boundary: the script must not import anything outside the
+    # Python standard library (it ships with the skill; pip installs are not).
+    run python3 - "$SCRIPT" <<'PY'
+import ast, sys
+tree = ast.parse(open(sys.argv[1]).read())
+allowed = {"json", "sys", "os", "re", "argparse", "datetime", "pathlib", "tempfile"}
+imports = set()
+for node in ast.walk(tree):
+    if isinstance(node, ast.Import):
+        imports |= {a.name.split(".")[0] for a in node.names}
+    elif isinstance(node, ast.ImportFrom) and node.module:
+        imports.add(node.module.split(".")[0])
+extra = imports - allowed
+assert not extra, f"non-stdlib imports: {sorted(extra)}"
+PY
+    [ "$status" -eq 0 ]
+}
+
+@test "closes a task atomically with closed-schema-valid output" {
+    python3 -c 'import jsonschema' 2>/dev/null || skip "jsonschema not installed"
+    run python3 "$SCRIPT" "$WORK/state.json" --task 1 --status completed \
+        --gate "bats tests/|0|suite green, 266/266" \
+        --worked "closed the loop" --commit abc1234
+    [ "$status" -eq 0 ]
+    # Atomicity: no temp file survives the replace.
+    [ ! -e "$WORK/state.json.tmp" ]
+    validates
+    python3 - "$WORK/state.json" <<'PY'
+import json, sys
+s = json.loads(open(sys.argv[1]).read())
+t = s["tasks"][0]
+assert t["status"] == "completed"
+assert t["commit"] == "abc1234"
+assert t["outcome"]["worked"] == "closed the loop"
+assert t["gates"][0]["passes"] is True and t["gates"][0]["exit_code"] == 0
+assert s["completed_count"] == 1
+assert s["status"] == "in_progress"
+assert s["checkpoint"]["task"] == 2
+assert s["approval"] == "approved" and s["format"] == "lite"
+PY
+}
+
+@test "idempotent modulo timestamps — a replayed close never double-counts" {
+    python3 "$SCRIPT" "$WORK/state.json" --task 1 --status completed \
+        --gate "bats tests/|0|suite green" --worked "w" >/dev/null
+    cp "$WORK/state.json" "$WORK/first.json"
+    python3 "$SCRIPT" "$WORK/state.json" --task 1 --status completed \
+        --gate "bats tests/|0|suite green" --worked "w" >/dev/null
+    python3 - "$WORK/first.json" "$WORK/state.json" <<'PY'
+import json, sys
+volatile = ("updated_at", "last_run", "started_at", "completed_at")
+def strip(obj):
+    if isinstance(obj, dict):
+        return {k: ("<ts>" if k in volatile else strip(v)) for k, v in obj.items()
+                if not (k == "checkpoint" and isinstance(v, dict))}
+    if isinstance(obj, list):
+        return [strip(x) for x in obj]
+    return obj
+a, b = (strip(json.load(open(p))) for p in sys.argv[1:3])
+assert a == b, f"replay changed state:\n{a}\nvs\n{b}"
+PY
+    validates
+}
+
+@test "derives plan completion and never rewrites the first close's timestamps" {
+    python3 "$SCRIPT" "$WORK/state.json" --task 1 --status completed >/dev/null
+    first_done="$(python3 -c 'import json;print(json.load(open("'"$WORK"'/state.json"))["tasks"][0]["completed_at"])')"
+    run python3 "$SCRIPT" "$WORK/state.json" --task 2 --status completed
+    [ "$status" -eq 0 ]
+    validates
+    python3 - "$WORK/state.json" "$first_done" <<'PY'
+import json, sys
+s = json.loads(open(sys.argv[1]).read())
+assert s["status"] == "completed" and s["completed_count"] == 2
+# Closing task 2 must not touch task 1's recorded completion time.
+assert s["tasks"][0]["completed_at"] == sys.argv[2]
+assert s["checkpoint"]["step"] == "done"
+PY
+}
+
+@test "invalid input is refused without writing anything" {
+    before="$(md5sum "$WORK/state.json" | cut -d' ' -f1)"
+    run python3 "$SCRIPT" "$WORK/state.json" --task 99 --status completed
+    [ "$status" -ne 0 ]
+    run python3 "$SCRIPT" "$WORK/state.json" --task 1 --status bogus
+    [ "$status" -ne 0 ]
+    run python3 "$SCRIPT" "$WORK/state.json" --task 1 --status completed --commit nothash
+    [ "$status" -ne 0 ]
+    run python3 "$SCRIPT" "$WORK/state.json" --task 1 --status completed \
+        --gate "cmd|0|$(printf 'x%.0s' $(seq 1 501))"
+    [ "$status" -ne 0 ]
+    run python3 "$SCRIPT" "$WORK/missing.json" --task 1 --status completed
+    [ "$status" -ne 0 ]
+    after="$(md5sum "$WORK/state.json" | cut -d' ' -f1)"
+    [ "$before" = "$after" ]
+}
+
+@test "the execute flow and the state spec teach the updater as the targeted path" {
+    EX="$REPO_ROOT/skills/deepworkplan/execute/SKILL.md"
+    PS="$REPO_ROOT/skills/deepworkplan/spec/PLAN_STATE.md"
+    grep -q 'shared/update-state.py' "$EX"
+    # Whole-file rewrite remains the documented fallback, not a ban.
+    tr '\n' ' ' < "$EX" | tr -s ' ' | grep -qF 'whole-file rewrite'
+    tr '\n' ' ' < "$EX" | tr -s ' ' | grep -qF 'atomic' || true
+    grep -q 'shared/update-state.py' "$PS"
+    # The spec keeps reconciliation (markdown wins) as whole-file regeneration.
+    tr '\n' ' ' < "$PS" | tr -s ' ' | grep -qF 'regenerate'
+}

--- a/tests/upgrade-subskill.bats
+++ b/tests/upgrade-subskill.bats
@@ -25,9 +25,28 @@ up_has() {
     grep -q 'documentation_url: https://deepworkplan.com' "$UP"
     run python3 "$REPO_ROOT/scripts/validate-frontmatter.py"
     [ "$status" -eq 0 ]
-    # The new file rides the pack version; the bot owns the number.
-    grep -q '^version: "4.0.3"$' "$UP"
-    grep -q '^version: "4.0.3"$' "$ROUTER"
+    # The sub-skill rides the pack version and the release bot owns the number,
+    # so the pin is DERIVED from the router's own frontmatter — never a literal.
+    # (F8-1: the released v5.0.0 tag shipped this test red because a hardcoded
+    # 4.0.3 literal survived the stamp.)
+    PACK_VERSION="$(grep -m1 '^version: ' "$ROUTER" | sed 's/^version: //')"
+    [ -n "$PACK_VERSION" ]
+    grep -qF "version: ${PACK_VERSION}" "$UP"
+}
+
+@test "pack version is identical across every SKILL.md (release stamps stay in sync)" {
+    first=""
+    for f in "$SK/SKILL.md" "$SK"/*/SKILL.md; do
+        v="$(grep -m1 '^version: ' "$f" | sed 's/^version: //')"
+        [ -n "$v" ]
+        if [ -z "$first" ]; then first="$v"; fi
+        [ "$v" = "$first" ]
+    done
+}
+
+@test "no test pins a literal pack version (the stamp owns the number)" {
+    run grep -rn 'version: "[0-9]' "$REPO_ROOT/tests"
+    [ "$status" -ne 0 ]
 }
 
 @test "the router routes to it and stays inside the pack boundary" {

--- a/tests/upgrade-subskill.bats
+++ b/tests/upgrade-subskill.bats
@@ -45,7 +45,10 @@ up_has() {
 }
 
 @test "no test pins a literal pack version (the stamp owns the number)" {
-    run grep -rn 'version: "[0-9]' "$REPO_ROOT/tests"
+    # The pattern is assembled at runtime so this test file itself cannot
+    # contain (and therefore cannot match) the forbidden literal.
+    pat="$(printf 'version: %s[0-9' '"')"
+    run grep -rn -- "$pat" "$REPO_ROOT/tests"
     [ "$status" -ne 0 ]
 }
 


### PR DESCRIPTION
## What this branch does

The released **v5.0.0** (`ab1337d`) was validated live against its own promises — installed into a clean Astro testbed, run through the Lite approval loop, orchestrator isolation, the upgrade path, and an honest-verifier battery. Every deviation found is fixed here, and the plan-file **format question** (JSON vs TOON/TOML/YAML for `manifest.json`/`state.json`) is settled with a measured decision record.

**Fixes (each pinned by a contract test):**
- **F8-1 (P1)** — the release stamp rewrites every `version:` frontmatter but no test literal, so the released tag shipped `tests/upgrade-subskill.bats` test 1 red (hardcoded `4.0.3`), latently CI-red (`[skip ci]` stamp). The pin is now **derived from the router's own frontmatter**, plus two regression tests: pack version identical across all 15 `SKILL.md` files, and no test may pin a literal quoted version. (`2f157c8`)
- **F3-1 / F4-1 / F3-4** — `dwp-verify.md` and `dwp-upgrade.md` delegator templates shipped (Phase 6 promised "one per `dwp-*` command"; a freshly onboarded repo had no command-file path to the upgrade flow); Phase 6/8 moved to the **seven-command kit**; the Phase 6 existing-repo note now covers zero-loss conversion of tool-created symlink-only `.claude/`/`.cursor/` directories. (`da40775`)
- **F6-1** — `create`'s Lite anatomy and Step 4.5 checklist now require the per-task **Context** field that `plan_contract.py` enforces. (`ac46d80`)
- **F1-1** — released-tree measurement appended to `docs/evaluations/hardening-2026-09.md` (the "final" column had measured a pre-stamp commit), per the record's own reproduce commands. (`7486a55`)

**Format decision — ADR 0002 (`2637cf3`):**
`manifest.json`/`state.json` **stay JSON**. The measured cost was never JSON's syntax but the **whole-file rewrite pattern**: re-emitting `state.json` at every task close costs ~843 KB across a 25-task plan (quadratic — every evidence string re-emitted once per later completion). TOON/TOML/YAML all break the verifier's Python 3.9+ **stdlib floor** (the honest-verifier contract) and only shrink the base of that quadratic term. Instead the pack ships `skills/deepworkplan/shared/update-state.py` — stdlib-only, atomic (temp+rename), idempotent modulo timestamps, closed-schema-valid output — so executors apply a task close as a bounded delta (~62 KB across the same plan, **−93%**). `execute`, `resume`, and `PLAN_STATE.md` §5.1 teach the one-line invocation; whole-file rewrite stays the documented fallback and markdown-wins reconciliation stays whole-file by design.

**Dogfood sync (`9f46b6a`):** the vendored mirror (113 files) refreshed via `scripts/refresh-dogfood-skill.sh`, lock hash re-stamped (algorithm verified against the untouched `ai-diff-reviewer` entry), byte-identity confirmed by an independent `diff -r`.

## Validation evidence

| Gate | Result |
|---|---|
| `bats tests/` | **272/272** (baseline 258 + 14 new tests; nothing deleted or weakened) |
| `python3 scripts/validate-frontmatter.py` | 15/15 OK |
| `shellcheck setup.sh …/context.sh scripts/*.sh` | clean |
| `diff -r skills/deepworkplan .agents/skills/deepworkplan` | identical |
| Live validation artifacts | onboarding, Lite loop, orchestrator-isolation leak/refute transcript, upgrade online/offline, honest-verifier exit-2 scenario — run in a clean testbed against the released tag before these fixes |

## Reviewer checklist

- [ ] Suite green at 272/272; no prior test deleted or weakened (the one title edit, six → seven commands, strengthens its loop)
- [ ] Dogfood mirror byte-identical; `skills-lock.json` hash matches
- [ ] `CHANGELOG.md` untouched (bot-owned; the release workflow versions this from the conventional commits — expect a **minor** bump: additive `feat` commits)
- [ ] ADR 0002 reopen conditions are acceptable (stdlib-grade TOON parser with write support + frozen escaping; state bytes entering prompts; agents bypassing the updater)
- [ ] New runtime file `shared/update-state.py` stays inside the pack boundary

## Note

**Do not merge until user-reviewed.** This branch is pushed for review only; the merge decision belongs to the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)